### PR TITLE
fix: alert stories + double alert details caret

### DIFF
--- a/.changeset/proud-ways-dance.md
+++ b/.changeset/proud-ways-dance.md
@@ -1,0 +1,6 @@
+---
+'@cypress-design/react-alert': patch
+'@cypress-design/vue-alert': patch
+---
+
+fix alert story and details caret on webkit

--- a/components/Alert/react/Alert.module.scss
+++ b/components/Alert/react/Alert.module.scss
@@ -1,0 +1,13 @@
+details.detailsBlock {
+  summary::-webkit-details-marker {
+    display: none;
+  }
+
+  summary .icon {
+    transform: rotate(-90deg);
+  }
+
+  &[open] summary .icon {
+    transform: rotate(0);
+  }
+}

--- a/components/Alert/react/Alert.tsx
+++ b/components/Alert/react/Alert.tsx
@@ -5,10 +5,10 @@ import {
   IconActionDeleteLarge,
   IconWarningCircle,
   IconCheckmarkOutline,
-  WindiColor,
 } from '@cypress-design/react-icon'
-import type { AlertType, AlertClasses } from '../constants'
+import type { AlertType } from '../constants'
 import { alertClasses } from '../constants'
+import styles from './Alert.module.scss'
 
 export interface AlertProps {
   /**
@@ -148,7 +148,8 @@ export const Alert: React.FC<AlertProps & React.HTMLProps<HTMLDivElement>> = ({
               className={clsx(
                 'p-16px border-t-1 cursor-pointer',
                 typeClasses.bodyClass,
-                typeClasses.borderClass
+                typeClasses.borderClass,
+                styles.detailsBlock
               )}
             >
               <summary

--- a/components/Alert/react/css-modules.d.ts
+++ b/components/Alert/react/css-modules.d.ts
@@ -1,0 +1,4 @@
+declare module '*.scss' {
+  const value: Record<string, string>
+  export default value
+}

--- a/components/Alert/react/package.json
+++ b/components/Alert/react/package.json
@@ -21,5 +21,10 @@
   "dependencies": {
     "clsx": "*"
   },
+  "devDependencies": {
+    "postcss": "^8.4.13",
+    "rollup-plugin-postcss": "^4.0.2",
+    "sass": "^1.51.0"
+  },
   "license": "MIT"
 }

--- a/components/Alert/react/rollup.config.js
+++ b/components/Alert/react/rollup.config.js
@@ -1,3 +1,13 @@
+import postcss from 'rollup-plugin-postcss'
 import rootRollupConfig from '../../root.rollup.config'
 
-export default rootRollupConfig({ input: './index.ts' })
+export default rootRollupConfig({
+  input: './index.ts',
+  plugins: [
+    postcss({
+      extract: false,
+      module: true,
+      use: ['sass'],
+    }),
+  ],
+})

--- a/components/Alert/react/tsconfig.build.json
+++ b/components/Alert/react/tsconfig.build.json
@@ -1,6 +1,11 @@
 {
   "extends": "../../../tsconfig.react.build.json",
-  "include": ["./Alert.tsx", "./index.ts", "../constants.ts"],
+  "include": [
+    "./Alert.tsx",
+    "./index.ts",
+    "../constants.ts",
+    "./css-modules.d.ts"
+  ],
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "../"

--- a/components/Alert/vue/Alert.rootstory.tsx
+++ b/components/Alert/vue/Alert.rootstory.tsx
@@ -3,7 +3,7 @@ import dedent from 'dedent'
 import { ref } from 'vue'
 import Alert from './Alert.vue'
 
-export default (() => ({
+export default () => ({
   setup() {
     const displayTimedAlert = ref(false)
     return () => (
@@ -107,4 +107,4 @@ export default (() => ({
       </div>
     )
   },
-}))()
+})

--- a/components/Alert/vue/Alert.stories.mdx
+++ b/components/Alert/vue/Alert.stories.mdx
@@ -17,7 +17,7 @@ import AlertStory from './Alert.rootstory'
 
 <Canvas withSource="none">
   <Story name="Alert">
-    {AlertStory()}
+    {AlertStory}
   </Story>
 </Canvas>
 

--- a/components/Alert/vue/Alert.vue
+++ b/components/Alert/vue/Alert.vue
@@ -133,6 +133,10 @@ const icon: ComputedRef<FunctionalComponent | null> = computed(() => {
 </script>
 
 <style scoped>
+details :deep(summary::-webkit-details-marker) {
+  display: none;
+}
+
 details summary .icon {
   transform: rotate(-90deg);
 }


### PR DESCRIPTION
The alert stories do not open for vue

https://design.cypress.io/?path=/story/vue_alert--alert

On react we have double icons on safari

https://design.cypress.io/?path=/story/react_alert--alert
<img width="506" alt="Screen Shot 2022-07-20 at 11 05 27 AM" src="https://user-images.githubusercontent.com/5592465/180029993-5225182a-3386-41cf-aa72-e66a5171571a.png">

