### PR TITLE
feat: create dot mjs files for esm

### DIFF
--- a/.changeset/orange-jars-sin.md
+++ b/.changeset/orange-jars-sin.md
@@ -1,0 +1,19 @@
+---
+"@cypress-design/react-alert": patch
+"@cypress-design/react-button": patch
+"@cypress-design/react-spinner": patch
+"@cypress-design/react-statusicon": patch
+"@cypress-design/react-tooltip": patch
+"@cypress-design/react-checkbox": patch
+"@cypress-design/react-icon": patch
+"@cypress-design/vue-alert": patch
+"@cypress-design/vue-button": patch
+"@cypress-design/vue-spinner": patch
+"@cypress-design/vue-statusicon": patch
+"@cypress-design/vue-tooltip": patch
+"@cypress-design/vue-checkbox": patch
+"@cypress-design/vue-icon": patch
+"@cypress-design/icon-registry": patch
+---
+
+feat: publish `.mjs` files for esm intead of `.js`

--- a/components/Alert/react/package.json
+++ b/components/Alert/react/package.json
@@ -6,10 +6,10 @@
   ],
   "typings": "./dist/react/index.d.ts",
   "main": "./dist/index.umd.js",
-  "module": "./dist/index.es.js",
+  "module": "./dist/index.es.mjs",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
+      "import": "./dist/index.es.mjs",
       "require": "./dist/index.umd.js"
     }
   },

--- a/components/Alert/vue/package.json
+++ b/components/Alert/vue/package.json
@@ -6,10 +6,10 @@
   ],
   "typings": "./dist/vue/index.d.ts",
   "main": "./dist/index.umd.js",
-  "module": "./dist/index.es.js",
+  "module": "./dist/index.es.mjs",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
+      "import": "./dist/index.es.mjs",
       "require": "./dist/index.umd.js"
     }
   },

--- a/components/Button/react/package.json
+++ b/components/Button/react/package.json
@@ -6,10 +6,10 @@
   ],
   "typings": "./dist/react/index.d.ts",
   "main": "./dist/index.umd.js",
-  "module": "./dist/index.es.js",
+  "module": "./dist/index.es.mjs",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
+      "import": "./dist/index.es.mjs",
       "require": "./dist/index.umd.js"
     }
   },

--- a/components/Button/vue/package.json
+++ b/components/Button/vue/package.json
@@ -6,10 +6,10 @@
   ],
   "typings": "./dist/vue/index.d.ts",
   "main": "./dist/index.umd.js",
-  "module": "./dist/index.es.js",
+  "module": "./dist/index.es.mjs",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
+      "import": "./dist/index.es.mjs",
       "require": "./dist/index.umd.js"
     }
   },

--- a/components/Spinner/react/package.json
+++ b/components/Spinner/react/package.json
@@ -6,10 +6,10 @@
   ],
   "typings": "./dist/index.d.ts",
   "main": "./dist/index.umd.js",
-  "module": "./dist/index.es.js",
+  "module": "./dist/index.es.mjs",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
+      "import": "./dist/index.es.mjs",
       "require": "./dist/index.umd.js"
     }
   },

--- a/components/Spinner/vue/package.json
+++ b/components/Spinner/vue/package.json
@@ -6,10 +6,10 @@
   ],
   "typings": "./dist/index.d.ts",
   "main": "./dist/index.umd.js",
-  "module": "./dist/index.es.js",
+  "module": "./dist/index.es.mjs",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
+      "import": "./dist/index.es.mjs",
       "require": "./dist/index.umd.js"
     },
     "./style.css": {

--- a/components/StatusIcon/react/package.json
+++ b/components/StatusIcon/react/package.json
@@ -6,10 +6,10 @@
   ],
   "typings": "./dist/index.d.ts",
   "main": "./dist/index.umd.js",
-  "module": "./dist/index.es.js",
+  "module": "./dist/index.es.mjs",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
+      "import": "./dist/index.es.mjs",
       "require": "./dist/index.umd.js"
     }
   },

--- a/components/StatusIcon/vue/package.json
+++ b/components/StatusIcon/vue/package.json
@@ -6,10 +6,10 @@
   ],
   "typings": "./dist/index.d.ts",
   "main": "./dist/index.umd.js",
-  "module": "./dist/index.es.js",
+  "module": "./dist/index.es.mjs",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
+      "import": "./dist/index.es.mjs",
       "require": "./dist/index.umd.js"
     }
   },

--- a/components/Tooltip/react/package.json
+++ b/components/Tooltip/react/package.json
@@ -6,10 +6,10 @@
   ],
   "typings": "./dist/index.d.ts",
   "main": "./dist/index.umd.js",
-  "module": "./dist/index.es.js",
+  "module": "./dist/index.es.mjs",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
+      "import": "./dist/index.es.mjs",
       "require": "./dist/index.umd.js"
     }
   },

--- a/components/Tooltip/vue/package.json
+++ b/components/Tooltip/vue/package.json
@@ -6,10 +6,10 @@
   ],
   "typings": "./dist/index.d.ts",
   "main": "./dist/index.umd.js",
-  "module": "./dist/index.es.js",
+  "module": "./dist/index.es.mjs",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
+      "import": "./dist/index.es.mjs",
       "require": "./dist/index.umd.js"
     }
   },

--- a/components/checkbox/react/package.json
+++ b/components/checkbox/react/package.json
@@ -6,10 +6,10 @@
   ],
   "typings": "./dist/index.d.ts",
   "main": "./dist/index.umd.js",
-  "module": "./dist/index.es.js",
+  "module": "./dist/index.es.mjs",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
+      "import": "./dist/index.es.mjs",
       "require": "./dist/index.umd.js"
     }
   },

--- a/components/checkbox/vue/package.json
+++ b/components/checkbox/vue/package.json
@@ -6,10 +6,10 @@
   ],
   "typings": "./dist/index.d.ts",
   "main": "./dist/index.umd.js",
-  "module": "./dist/index.es.js",
+  "module": "./dist/index.es.mjs",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
+      "import": "./dist/index.es.mjs",
       "require": "./dist/index.umd.js"
     }
   },

--- a/components/icon/react/package.json
+++ b/components/icon/react/package.json
@@ -6,10 +6,10 @@
   ],
   "typings": "./dist/index.d.ts",
   "main": "./dist/index.umd.js",
-  "module": "./dist/index.es.js",
+  "module": "./dist/index.es.mjs",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
+      "import": "./dist/index.es.mjs",
       "require": "./dist/index.umd.js"
     }
   },

--- a/components/icon/vue/Icon.ts
+++ b/components/icon/vue/Icon.ts
@@ -1,11 +1,9 @@
 import { compileIcon } from '@cypress-design/icon-registry'
 import type { IconProps } from '@cypress-design/icon-registry'
-import { defineComponent, h } from 'vue'
+import { h } from 'vue'
 import type { SVGAttributes } from 'vue'
 import { compileVueIconProperties } from './compileProperties'
 
-export default defineComponent(
-  (props: IconProps & Omit<SVGAttributes, 'name'>) => {
-    return h('svg', compileVueIconProperties(compileIcon(props)))
-  }
-)
+export default (props: IconProps & Omit<SVGAttributes, 'name'>) => {
+  return h('svg', compileVueIconProperties(compileIcon(props)))
+}

--- a/components/icon/vue/package.json
+++ b/components/icon/vue/package.json
@@ -17,7 +17,7 @@
     "build": "yarn build:codegen && yarn build:module && yarn build:types",
     "build:codegen": "node ./generate-icons.js",
     "build:module": "yarn vite build",
-    "build:types": "yarn vue-tsc --project ./tsconfig.build.json"
+    "build:types": "yarn tsc --project ./tsconfig.build.json"
   },
   "dependencies": {
     "@cypress-design/icon-registry": "^0.6.0"

--- a/components/icon/vue/package.json
+++ b/components/icon/vue/package.json
@@ -6,10 +6,10 @@
   ],
   "typings": "./dist/index.d.ts",
   "main": "./dist/index.umd.js",
-  "module": "./dist/index.es.js",
+  "module": "./dist/index.es.mjs",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
+      "import": "./dist/index.es.mjs",
       "require": "./dist/index.umd.js"
     }
   },

--- a/components/root.rollup.config.js
+++ b/components/root.rollup.config.js
@@ -17,7 +17,7 @@ export default ({ input, plugins = [] }) => ({
           : sourcePath.replace(/^\.\.\/\.\.\/(\w)/, `../../react/$1`),
     },
     {
-      file: './dist/index.es.js',
+      file: './dist/index.es.mjs',
       format: 'esm',
       sourcemap: true,
       sourcemapPathTransform: (sourcePath) =>

--- a/components/root.vite.config.ts
+++ b/components/root.vite.config.ts
@@ -8,7 +8,8 @@ export default (libConfig: LibraryOptions) =>
     build: {
       sourcemap: true,
       lib: {
-        fileName: (format) => `index.${format}.js`,
+        fileName: (format) =>
+          `index.${format === 'es' ? 'es.mjs' : `${format}.js`}`,
         ...libConfig,
       },
       rollupOptions: {

--- a/icon-registry/package.json
+++ b/icon-registry/package.json
@@ -23,14 +23,12 @@
   "files": [
     "dist"
   ],
-  "dependencies": {
-    "lodash": "^4.17.21"
-  },
   "devDependencies": {
-    "@types/lodash": "^4.14.182",
+    "@types/lodash.camelcase": "^4.3.7",
     "@cypress-design/css": "^0.6.0",
     "dedent": "^0.7.0",
     "globby": "^13.1.1",
+    "lodash.camelcase": "^4.3.0",
     "svg-to-ts": "^8.6.1"
   },
   "svg-to-ts": {

--- a/icon-registry/package.json
+++ b/icon-registry/package.json
@@ -2,21 +2,23 @@
   "name": "@cypress-design/icon-registry",
   "version": "0.6.0",
   "description": "All svg files to be exposed to the Icon component",
-  "main": "dist/cjs/index.js",
-  "types": "dist/types/index.d.ts",
+  "main": "dist/index.umd.js",
+  "module": "dist/index.es.mjs",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "import": "./dist/index.es.mjs",
+      "require": "./dist/index.umd.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "license": "MIT",
   "scripts": {
-    "build:lib": "tsc -p tsconfig.json",
-    "build:libcjs": "tsc -p tsconfig.json --module commonjs --outDir \"dist/cjs\" --declaration false --declarationMap false --declarationDir null",
+    "build:lib": "rollup -c ./rollup.config.js",
+    "build:types": "tsc -p . --outDir ./dist --noEmit false --emitDeclarationOnly",
     "build:icons": "node ./build-icons.mjs",
     "build:svg": "svg-to-ts-files",
-    "build": "yarn build:icons && yarn build:svg && yarn build:lib && yarn build:libcjs"
+    "build": "yarn build:icons && yarn build:svg && yarn build:lib && yarn build:types"
   },
   "files": [
     "dist"

--- a/icon-registry/rollup.config.js
+++ b/icon-registry/rollup.config.js
@@ -11,9 +11,6 @@ export default {
       exports: 'auto',
       sourcemap: true,
       name: 'CypressIconRegistry',
-      globals: {
-        lodash: 'lodash',
-      },
     },
     {
       file: './dist/index.es.mjs',
@@ -32,5 +29,4 @@ export default {
       outDir: './dist',
     }),
   ],
-  external: ['lodash'],
 }

--- a/icon-registry/rollup.config.js
+++ b/icon-registry/rollup.config.js
@@ -1,0 +1,36 @@
+import commonjs from '@rollup/plugin-commonjs'
+import resolve from '@rollup/plugin-node-resolve'
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: './src/index.ts',
+  output: [
+    {
+      file: './dist/index.umd.js',
+      format: 'umd',
+      exports: 'auto',
+      sourcemap: true,
+      name: 'CypressIconRegistry',
+      globals: {
+        lodash: 'lodash',
+      },
+    },
+    {
+      file: './dist/index.es.mjs',
+      format: 'esm',
+      sourcemap: true,
+    },
+  ],
+  plugins: [
+    resolve(),
+    commonjs(),
+    typescript({
+      tsconfig: './tsconfig.json',
+      sourceMap: true,
+      declaration: false,
+      declarationMap: false,
+      outDir: './dist',
+    }),
+  ],
+  external: ['lodash'],
+}

--- a/icon-registry/src/compileIcon.ts
+++ b/icon-registry/src/compileIcon.ts
@@ -1,4 +1,4 @@
-import { camelCase } from 'lodash'
+import camelCase from 'lodash.camelcase'
 import type { OpenIconProps, IconProps, WindiColor } from './icons'
 import { iconsMetadata, ICON_COLOR_PROP_NAMES } from './icons'
 import { iconSet } from './iconsList'

--- a/icon-registry/tsconfig.json
+++ b/icon-registry/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "include": ["src/**/*.ts"],
   "compilerOptions": {
-    "outDir": "dist/esm",
     "target": "ES2015",
     "module": "esnext",
     "moduleResolution": "node",
@@ -10,6 +9,6 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "declarationMap": true,
-    "declarationDir": "dist/types"
+    "noEmit": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -69,14 +69,14 @@
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "typescript": "4.4.4",
-    "vite": "^3.0.2",
+    "vite": "^3.0.4",
     "vitest": "^0.18.1",
     "vue-eslint-parser": "^9.0.2",
-    "vue-tsc": "^0.33.9"
+    "vue-tsc": "^0.39.4"
   },
   "lint-staged": {
     "*.{js,ts,jsx,tsx,vue}": "eslint --cache --fix",
-    "*.{js,css,md}": "prettier --write"
+    "*.{js,ts,jsx,tsx,vue,css,md}": "prettier --write"
   },
   "gitHooks": {
     "pre-commit": "lint-staged"

--- a/storybook/intro/.storybook/main.js
+++ b/storybook/intro/.storybook/main.js
@@ -101,6 +101,13 @@ module.exports = {
         ),
       })
     )
+    config.module.rules.push(
+      // allow support for mjs module in webpack
+      {
+        type: 'javascript/auto',
+        test: /.+\.mjs$/,
+      }
+    )
     return config
   },
 }

--- a/storybook/react/.storybook/main.js
+++ b/storybook/react/.storybook/main.js
@@ -30,6 +30,11 @@ module.exports = {
         },
       })
     )
+    // allow support for mjs module in webpack
+    config.module.rules.push({
+      type: 'javascript/auto',
+      test: /.+\.mjs$/,
+    })
     config.resolve.extensions.push('.json')
     return config
   },

--- a/test/vue-app/package.json
+++ b/test/vue-app/package.json
@@ -22,8 +22,8 @@
     "@vitejs/plugin-vue": "^2.3.1",
     "@vue/tsconfig": "^0.1.3",
     "typescript": "~4.6.3",
-    "vite": "^2.9.5",
-    "vue-tsc": "^0.34.7"
+    "vite": "^3.0.4",
+    "vue-tsc": "^0.39.4"
   },
   "license": "MIT"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2918,7 +2918,14 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
-"@types/lodash@^4.14.167", "@types/lodash@^4.14.182":
+"@types/lodash.camelcase@^4.3.7":
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash.camelcase/-/lodash.camelcase-4.3.7.tgz#b0a06a216542335c0326c0d2fbad3f121b1f29a7"
+  integrity sha512-Nfi6jpo9vuEOSIJP+mpbTezKyEt75DQlbwjiDvs/JctWkbnHDoyQo5lWqdvgNiJmVUjcmkfvlrvSEgJYvurOKg==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*", "@types/lodash@^4.14.167", "@types/lodash@^4.14.182":
   version "4.14.182"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
   integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3308,105 +3308,55 @@
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-2.3.3.tgz#fbf80cc039b82ac21a1acb0f0478de8f61fbf600"
   integrity sha512-SmQLDyhz+6lGJhPELsBdzXGc+AcaT8stgkbiTFGpXPe8Tl1tJaBw1A6pxDqDuRsVkD8uscrkx3hA7QDOoKYtyw==
 
-"@volar/code-gen@0.33.9":
-  version "0.33.9"
-  resolved "https://registry.yarnpkg.com/@volar/code-gen/-/code-gen-0.33.9.tgz#5d108451c4872fb905eab59143b64b824610eed0"
-  integrity sha512-HI+XemEjvOv9uSjqaNXIL1brSTaBy9vRTcXqz9787nL5VKktI8aU1Zk4w9yJR88eTqw7mlPIdMaib7Ps/QPq8Q==
+"@volar/code-gen@0.39.4":
+  version "0.39.4"
+  resolved "https://registry.yarnpkg.com/@volar/code-gen/-/code-gen-0.39.4.tgz#89d025af12d537ff7236ebab3dda0eb7bdc2175b"
+  integrity sha512-2RoDdktnN5ovhJoL1NgxKwKhfgP2TzcKVWp8+1Lb67sZ+hvWRL5GjHGkvlPkS91cElpwuURUHnbNNDT+uEqXuA==
   dependencies:
-    "@volar/source-map" "0.33.9"
+    "@volar/source-map" "0.39.4"
 
-"@volar/code-gen@0.34.17":
-  version "0.34.17"
-  resolved "https://registry.yarnpkg.com/@volar/code-gen/-/code-gen-0.34.17.tgz#fd46e369454e6bd9599b511500b4c43acb9730bd"
-  integrity sha512-rHR7BA71BJ/4S7xUOPMPiB7uk6iU9oTWpEMZxFi5VGC9iJmDncE82WzU5iYpcbOBCVHsOjMh0+5CGMgdO6SaPA==
+"@volar/source-map@0.39.4":
+  version "0.39.4"
+  resolved "https://registry.yarnpkg.com/@volar/source-map/-/source-map-0.39.4.tgz#a6d059f04d0ae66777375edff4f78dc6b6780bbf"
+  integrity sha512-0zp7v0Ta1rZ2nKC4RcsU94Q/wJVVDWD0AJIqRGFU8rlEs2QO+RpBgotTL6wnKyJjyTzXxhcz/7AHUcwFs2oRnw==
+
+"@volar/typescript-faster@0.39.4":
+  version "0.39.4"
+  resolved "https://registry.yarnpkg.com/@volar/typescript-faster/-/typescript-faster-0.39.4.tgz#d02d2f5eedce9b0651f625819680349f2d4ba650"
+  integrity sha512-nVwTr1MSeUOjm+piJge3WW8PE+JyYbkfpEsf54P0e4P+8PUPHbGRIgr2TSpAh3802JSqg2SHCoDionECT5aXYw==
   dependencies:
-    "@volar/source-map" "0.34.17"
+    semver "^7.3.7"
 
-"@volar/pug-language-service@0.33.9":
-  version "0.33.9"
-  resolved "https://registry.yarnpkg.com/@volar/pug-language-service/-/pug-language-service-0.33.9.tgz#e5f94cd9f3eca5012b35d9360236e6259528492a"
-  integrity sha512-3oOV0HmoqkCyPAiHXSMoDzbLrSEQQv3d1dY/Lfo4H8hGoS8kUYJ958328TuLFc90yzsSmYnuvIux5AUok138pg==
+"@volar/vue-code-gen@0.39.4":
+  version "0.39.4"
+  resolved "https://registry.yarnpkg.com/@volar/vue-code-gen/-/vue-code-gen-0.39.4.tgz#b838a8075784036a3829a1747f5595b66e60566d"
+  integrity sha512-jQwweKAgtKhX7kDvsVcBRieyNtEywoxZFN+XTyPRvtY57Z2B7Ei9zQb/01n1l2lI+FPuskxaXdZKCn4txSKojQ==
   dependencies:
-    "@volar/code-gen" "0.33.9"
-    "@volar/shared" "0.33.9"
-    "@volar/source-map" "0.33.9"
-    "@volar/transforms" "0.33.9"
-    pug-lexer "^5.0.1"
-    pug-parser "^6.0.0"
-    vscode-languageserver-textdocument "^1.0.3"
-    vscode-languageserver-types "^3.17.0-next.6"
+    "@volar/code-gen" "0.39.4"
+    "@volar/source-map" "0.39.4"
+    "@vue/compiler-core" "^3.2.37"
+    "@vue/compiler-dom" "^3.2.37"
+    "@vue/shared" "^3.2.37"
 
-"@volar/shared@0.33.9":
-  version "0.33.9"
-  resolved "https://registry.yarnpkg.com/@volar/shared/-/shared-0.33.9.tgz#4a7244cafab2011c1a7942f22754e08a21f08cf7"
-  integrity sha512-YqEBYT1SjyO+/W73lyKZlftumimsrYGvd98pHrIyvgc6HNhFnCcthRbyHskstjU6P8Bgj90mRl+7Sb29J+Z5ng==
+"@volar/vue-language-core@0.39.4":
+  version "0.39.4"
+  resolved "https://registry.yarnpkg.com/@volar/vue-language-core/-/vue-language-core-0.39.4.tgz#15cee0a964f92a3cb888a51da8dcf456d861bdcd"
+  integrity sha512-ua4HAT8VYSf3EgY4Fl/mfpOQcUWz3gokJ8qsGIGfgKq3MxORnpp+RzKOEpMo1q+Ic550i+x0fh6Ylde76zOLww==
   dependencies:
-    upath "^2.0.1"
-    vscode-jsonrpc "^8.0.0-next.5"
-    vscode-uri "^3.0.3"
+    "@volar/code-gen" "0.39.4"
+    "@volar/source-map" "0.39.4"
+    "@volar/vue-code-gen" "0.39.4"
+    "@vue/compiler-sfc" "^3.2.37"
+    "@vue/reactivity" "^3.2.37"
 
-"@volar/source-map@0.33.9":
-  version "0.33.9"
-  resolved "https://registry.yarnpkg.com/@volar/source-map/-/source-map-0.33.9.tgz#d86d9db30b15e554f4d0d2853e03a84ae1bc1ebd"
-  integrity sha512-SE7dfumZ8pLsbj4DtiSDTg2/d/JT45nF51rUnuz1UNSBPEeXBexlzvz5EQ2AyrX0FjAAd2ijrRtirTk1a0SFhQ==
-
-"@volar/source-map@0.34.17":
-  version "0.34.17"
-  resolved "https://registry.yarnpkg.com/@volar/source-map/-/source-map-0.34.17.tgz#79efc4d088e11f59fc857953185a1f852df70968"
-  integrity sha512-3yn1IMXJGGWB/G817/VFlFMi8oh5pmE7VzUqvgMZMrppaZpKj6/juvJIEiXNxRsgWc0RxIO8OSp4htdPUg1Raw==
-
-"@volar/transforms@0.33.9":
-  version "0.33.9"
-  resolved "https://registry.yarnpkg.com/@volar/transforms/-/transforms-0.33.9.tgz#1155b5ea01b67bc318dddb49177f6c2df6b6f879"
-  integrity sha512-qdc2d0ZW/G6jCx1pBmoMjMJTY245pZJjpPL/OCT3zgbDLGvLvqhowXxQYQd2YiNXqxJvbadEKviH5LiZL3sU9g==
+"@volar/vue-typescript@0.39.4":
+  version "0.39.4"
+  resolved "https://registry.yarnpkg.com/@volar/vue-typescript/-/vue-typescript-0.39.4.tgz#e171d6e132915c4aa30c6391b11b9f72106517c0"
+  integrity sha512-ZIWg8EvTq53+P4DQVlrW5y+bo5v9VTOASBTrojBo0yK2frNbv/Gs7Ml4V+NmlsvIggtrPtDC/hIQChFiS5B3SA==
   dependencies:
-    "@volar/shared" "0.33.9"
-    vscode-languageserver-types "^3.17.0-next.6"
-
-"@volar/vue-code-gen@0.33.9":
-  version "0.33.9"
-  resolved "https://registry.yarnpkg.com/@volar/vue-code-gen/-/vue-code-gen-0.33.9.tgz#353b5803d9cf84b14f9a5e2e1c661a072d776736"
-  integrity sha512-qRCXcBhm1kUlI06sW5zolavn8gqZdSC2eIWw7jgbW68K/cGlTyXHGGZgJPM9P22cF9pcrjV1ByehO18ke2u+aA==
-  dependencies:
-    "@volar/code-gen" "0.33.9"
-    "@volar/source-map" "0.33.9"
-    "@vue/compiler-core" "^3.2.27"
-    "@vue/compiler-dom" "^3.2.27"
-    "@vue/shared" "^3.2.27"
-
-"@volar/vue-code-gen@0.34.17":
-  version "0.34.17"
-  resolved "https://registry.yarnpkg.com/@volar/vue-code-gen/-/vue-code-gen-0.34.17.tgz#55ca9c21b38c91bf362761b268a77b9f0ecae8bf"
-  integrity sha512-17pzcK29fyFWUc+C82J3JYSnA+jy3QNrIldb9kPaP9Itbik05ZjEIyEue9FjhgIAuHeYSn4LDM5s6nGjxyfhsQ==
-  dependencies:
-    "@volar/code-gen" "0.34.17"
-    "@volar/source-map" "0.34.17"
-    "@vue/compiler-core" "^3.2.36"
-    "@vue/compiler-dom" "^3.2.36"
-    "@vue/shared" "^3.2.36"
-
-"@volar/vue-typescript@0.33.9":
-  version "0.33.9"
-  resolved "https://registry.yarnpkg.com/@volar/vue-typescript/-/vue-typescript-0.33.9.tgz#6ac36812bba3967af316c0710559bf12bab904e8"
-  integrity sha512-UUViaQfzAV7z49TB+IsGCT6ls7zdEUib2N0L4k8U9nZbd2BQA4kcR9nyS/8oDOU5fK3ErP+pPlC+XzGGamKhcw==
-  dependencies:
-    "@volar/code-gen" "0.33.9"
-    "@volar/pug-language-service" "0.33.9"
-    "@volar/source-map" "0.33.9"
-    "@volar/vue-code-gen" "0.33.9"
-    "@vue/compiler-sfc" "^3.2.27"
-    "@vue/reactivity" "^3.2.27"
-
-"@volar/vue-typescript@0.34.17":
-  version "0.34.17"
-  resolved "https://registry.yarnpkg.com/@volar/vue-typescript/-/vue-typescript-0.34.17.tgz#497eb471ebac25ff61af04031b78ec71a34d470b"
-  integrity sha512-U0YSVIBPRWVPmgJHNa4nrfq88+oS+tmyZNxmnfajIw9A/GOGZQiKXHC0k09SVvbYXlsjgJ6NIjhm9NuAhGRQjg==
-  dependencies:
-    "@volar/code-gen" "0.34.17"
-    "@volar/source-map" "0.34.17"
-    "@volar/vue-code-gen" "0.34.17"
-    "@vue/compiler-sfc" "^3.2.36"
-    "@vue/reactivity" "^3.2.36"
+    "@volar/code-gen" "0.39.4"
+    "@volar/typescript-faster" "0.39.4"
+    "@volar/vue-language-core" "0.39.4"
 
 "@vue/babel-helper-vue-transform-on@^1.0.2":
   version "1.0.2"
@@ -3428,7 +3378,7 @@
     html-tags "^3.1.0"
     svg-tags "^1.0.0"
 
-"@vue/compiler-core@3.2.37", "@vue/compiler-core@^3.2.27", "@vue/compiler-core@^3.2.36":
+"@vue/compiler-core@3.2.37", "@vue/compiler-core@^3.2.37":
   version "3.2.37"
   resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.2.37.tgz#b3c42e04c0e0f2c496ff1784e543fbefe91e215a"
   integrity sha512-81KhEjo7YAOh0vQJoSmAD68wLfYqJvoiD4ulyedzF+OEk/bk6/hx3fTNVfuzugIIaTrOx4PGx6pAiBRe5e9Zmg==
@@ -3438,7 +3388,7 @@
     estree-walker "^2.0.2"
     source-map "^0.6.1"
 
-"@vue/compiler-dom@3.2.37", "@vue/compiler-dom@^3.2.0", "@vue/compiler-dom@^3.2.27", "@vue/compiler-dom@^3.2.36":
+"@vue/compiler-dom@3.2.37", "@vue/compiler-dom@^3.2.0", "@vue/compiler-dom@^3.2.37":
   version "3.2.37"
   resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.2.37.tgz#10d2427a789e7c707c872da9d678c82a0c6582b5"
   integrity sha512-yxJLH167fucHKxaqXpYk7x8z7mMEnXOw3G2q62FTkmsvNxu4FQSu5+3UMb+L7fjKa26DEzhrmCxAgFLLIzVfqQ==
@@ -3446,7 +3396,7 @@
     "@vue/compiler-core" "3.2.37"
     "@vue/shared" "3.2.37"
 
-"@vue/compiler-sfc@3.2.37", "@vue/compiler-sfc@^3.2.0", "@vue/compiler-sfc@^3.2.27", "@vue/compiler-sfc@^3.2.36":
+"@vue/compiler-sfc@3.2.37", "@vue/compiler-sfc@^3.2.0", "@vue/compiler-sfc@^3.2.37":
   version "3.2.37"
   resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.2.37.tgz#3103af3da2f40286edcd85ea495dcb35bc7f5ff4"
   integrity sha512-+7i/2+9LYlpqDv+KTtWhOZH+pa8/HnX/905MdVmAcI/mPQOBwkHHIzrsEsucyOIZQYMkXUiTkmZq5am/NyXKkg==
@@ -3481,7 +3431,7 @@
     estree-walker "^2.0.2"
     magic-string "^0.25.7"
 
-"@vue/reactivity@3.2.37", "@vue/reactivity@^3.2.27", "@vue/reactivity@^3.2.36":
+"@vue/reactivity@3.2.37", "@vue/reactivity@^3.2.37":
   version "3.2.37"
   resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.2.37.tgz#5bc3847ac58828e2b78526e08219e0a1089f8848"
   integrity sha512-/7WRafBOshOc6m3F7plwzPeCu/RCVv9uMpOwa/5PiY1Zz+WLVRWiy0MYKwmg19KBdGtFWsmZ4cD+LOdVPcs52A==
@@ -3513,7 +3463,7 @@
     "@vue/compiler-ssr" "3.2.37"
     "@vue/shared" "3.2.37"
 
-"@vue/shared@3.2.37", "@vue/shared@^3.2.27", "@vue/shared@^3.2.36":
+"@vue/shared@3.2.37", "@vue/shared@^3.2.37":
   version "3.2.37"
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.37.tgz#8e6adc3f2759af52f0e85863dfb0b711ecc5c702"
   integrity sha512-4rSJemR2NQIo9Klm1vabqWjD8rs/ZaJSzMxkMNeJS6lHiUjjUeYFbooN19NgFjztubEKh3WlZUeOLVdbbUWHsw==
@@ -14293,11 +14243,6 @@ upath@^1.1.1:
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
 
-upath@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-2.0.1.tgz#50c73dea68d6f6b990f51d279ce6081665d61a8b"
-  integrity sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==
-
 update-browserslist-db@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.3.tgz#6c47cb996f34afb363e924748e2f6e4d983c6fc1"
@@ -14488,7 +14433,7 @@ vite-plugin-windicss@^1.8.4:
     kolorist "^1.5.1"
     windicss "^3.5.1"
 
-"vite@^2.9.12 || ^3.0.0-0", vite@^3.0.2:
+"vite@^2.9.12 || ^3.0.0-0":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/vite/-/vite-3.0.2.tgz#2a7b4642c53ae066cf724e7e581d6c1fd24e2c32"
   integrity sha512-TAqydxW/w0U5AoL5AsD9DApTvGb2iNbGs3sN4u2VdT1GFkQVUfgUldt+t08TZgi23uIauh1TUOQJALduo9GXqw==
@@ -14509,6 +14454,18 @@ vite@^2.9.5:
     postcss "^8.4.13"
     resolve "^1.22.0"
     rollup "^2.59.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+vite@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-3.0.4.tgz#c61688d6b97573e96cf5ac25f2d68597b5ce68e8"
+  integrity sha512-NU304nqnBeOx2MkQnskBQxVsa0pRAH5FphokTGmyy8M3oxbvw7qAXts2GORxs+h/2vKsD+osMhZ7An6yK6F1dA==
+  dependencies:
+    esbuild "^0.14.47"
+    postcss "^8.4.14"
+    resolve "^1.22.1"
+    rollup "^2.75.6"
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -14536,26 +14493,6 @@ void-elements@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
   integrity sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==
-
-vscode-jsonrpc@^8.0.0-next.5:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz#f30b0625ebafa0fb3bc53e934ca47b706445e57e"
-  integrity sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==
-
-vscode-languageserver-textdocument@^1.0.3:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.5.tgz#838769940ece626176ec5d5a2aa2d0aa69f5095c"
-  integrity sha512-1ah7zyQjKBudnMiHbZmxz5bYNM9KKZYz+5VQLj+yr8l+9w3g+WAhCkUkWbhMEdC5u0ub4Ndiye/fDyS8ghIKQg==
-
-vscode-languageserver-types@^3.17.0-next.6:
-  version "3.17.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz#c2d87fa7784f8cac389deb3ff1e2d9a7bef07e16"
-  integrity sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ==
-
-vscode-uri@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.3.tgz#a95c1ce2e6f41b7549f86279d19f47951e4f4d84"
-  integrity sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==
 
 vue-docgen-api@^4.44.15:
   version "4.47.0"
@@ -14619,19 +14556,13 @@ vue-loader@^16.4.1:
     hash-sum "^2.0.0"
     loader-utils "^2.0.0"
 
-vue-tsc@^0.33.9:
-  version "0.33.9"
-  resolved "https://registry.yarnpkg.com/vue-tsc/-/vue-tsc-0.33.9.tgz#96f81eeb0f141b7f0ab73a31941034fce823785e"
-  integrity sha512-s/+r4JNsCh4e3MUdsYrjEA8IgPPDzHL5kEah/OznxIHd1XMlYiIkXGdiyU6JE5J+lzXNOKdOlNliqwwpeETQWw==
+vue-tsc@^0.39.4:
+  version "0.39.4"
+  resolved "https://registry.yarnpkg.com/vue-tsc/-/vue-tsc-0.39.4.tgz#4ca8d252de912e0f7fbcc097742a506ce8d89f7c"
+  integrity sha512-oGFuAdSt8Q1NatnyyJheW0P/8Sk9RDMWPNzeMHXl1OOnoXrbjz2miMcccujySCpA48+AhzdtyFY1PL0XTPsOSg==
   dependencies:
-    "@volar/vue-typescript" "0.33.9"
-
-vue-tsc@^0.34.7:
-  version "0.34.17"
-  resolved "https://registry.yarnpkg.com/vue-tsc/-/vue-tsc-0.34.17.tgz#332fc5c31d64bb9b74b0f26050f3ab067a9a7d6f"
-  integrity sha512-jzUXky44ZLHC4daaJag7FQr3idlPYN719/K1eObGljz5KaS2UnVGTU/XSYCd7d6ampYYg4OsyalbHyJIxV0aEQ==
-  dependencies:
-    "@volar/vue-typescript" "0.34.17"
+    "@volar/vue-language-core" "0.39.4"
+    "@volar/vue-typescript" "0.39.4"
 
 vue@^3.2.31, vue@^3.2.33:
   version "3.2.37"


### PR DESCRIPTION
Astro is a bit more stringent than just vite since it is doing SSG and SSR.

It needs all modules/components to work on both node and in the browser.

ESM does not work natively in node. 

We have to rename the files `.mjs` to make it work.