### PR TITLE
feat: shared constants

### DIFF
--- a/_templates/component/new/components_ComponentName_assertions.ts.ejs.t
+++ b/_templates/component/new/components_ComponentName_assertions.ts.ejs.t
@@ -1,0 +1,10 @@
+---
+to: components/<%= h.inflection.camelize(name, false) %>/assertions.ts
+---
+/// <reference types="cypress" />
+
+export default function assertions(mountStory: (options?: any) => void): void {
+  it('renders', () => {
+    mountStory()
+  })
+}

--- a/_templates/component/new/components_ComponentName_constants.ts.ejs.t
+++ b/_templates/component/new/components_ComponentName_constants.ts.ejs.t
@@ -1,0 +1,8 @@
+---
+to: components/<%= h.inflection.camelize(name, false) %>/constants.ts
+---
+export const SharedSettings = {
+  foo: '-',
+  bar: 42,
+  baz: false,
+}

--- a/_templates/component/new/components_ComponentName_react_ComponentName.cy.tsx.ejs.t
+++ b/_templates/component/new/components_ComponentName_react_ComponentName.cy.tsx.ejs.t
@@ -6,9 +6,11 @@ to: components/<%= h.inflection.camelize(name, false) %>/react/<%= h.inflection.
 import * as React from 'react'
 import { mount } from 'cypress/react'
 import <%= h.inflection.camelize(name, false) %>Story from './<%= h.inflection.camelize(name, false) %>.rootstory'
+import assertions from '../assertions'
 
 describe('<%= h.inflection.camelize(name, false) %>', () => {
-  it('renders', () => {
-    mount(<<%= h.inflection.camelize(name, false) %>Story />)
-  })
+  function mountStory(options: Parameters<typeof <%= h.inflection.camelize(name, false) %>Story>[0] = {}) {
+    mount(<<%= h.inflection.camelize(name, false) %>Story {...options} />)
+  }
+  assertions(mountStory)
 })

--- a/_templates/component/new/components_ComponentName_react_ComponentName.rootstory.tsx.ejs.t
+++ b/_templates/component/new/components_ComponentName_react_ComponentName.rootstory.tsx.ejs.t
@@ -4,4 +4,7 @@ to: components/<%= h.inflection.camelize(name, false) %>/react/<%= h.inflection.
 import * as React from 'react'
 import <%= h.inflection.camelize(name, false) %> from './<%= h.inflection.camelize(name, false) %>'
 
-export default () => <<%= h.inflection.camelize(name, false) %> id="foo" />
+export default (options: { id?: string }) => {
+  const { id = 'foo', ...rest } = options
+  return <<%= h.inflection.camelize(name, false) %> id={id} {...rest} />
+}

--- a/_templates/component/new/components_ComponentName_react_ComponentName.tsx.ejs.t
+++ b/_templates/component/new/components_ComponentName_react_ComponentName.tsx.ejs.t
@@ -3,8 +3,7 @@ to: components/<%= h.inflection.camelize(name, false) %>/react/<%= h.inflection.
 ---
 import * as React from 'react'
 import clsx from 'clsx'
-
-const styles: Record<string, string> = {}
+import { SharedSettings } from '../constants'
 
 export interface <%= h.inflection.camelize(name, false) %>Props {
   id: string
@@ -19,6 +18,7 @@ export const <%= h.inflection.camelize(name, false) %>: React.FC<
     <div {...rest} id={id} className={clsx('bg-jade-100', className)}>
       <label>{label}</label>
       Render Function for <%= h.inflection.camelize(name, false) %>
+      <p>{SharedSettings.foo}</p>
     </div>
   )
 }

--- a/_templates/component/new/components_ComponentName_react_package.json.ejs.t
+++ b/_templates/component/new/components_ComponentName_react_package.json.ejs.t
@@ -7,7 +7,7 @@ to: components/<%= h.inflection.camelize(name, false) %>/react/package.json
   "files": [
     "*"
   ],
-  "typings": "./dist/index.d.ts",
+  "typings": "./dist/react/index.d.ts",
   "module": "./dist/index.es.mjs",
   "main": "./dist/index.umd.js",
   "exports": {

--- a/_templates/component/new/components_ComponentName_react_tsconfig.build.json.ejs.t
+++ b/_templates/component/new/components_ComponentName_react_tsconfig.build.json.ejs.t
@@ -3,7 +3,7 @@ to: components/<%= h.inflection.camelize(name, false) %>/react/tsconfig.build.js
 ---
 {
   "extends": "../../../tsconfig.react.build.json",
-  "include": ["./<%= h.inflection.camelize(name, false) %>.tsx", "./index.ts"],
+  "include": ["./<%= h.inflection.camelize(name, false) %>.tsx", "./index.ts", "../*.ts"],
   "compilerOptions": {
     "outDir": "dist"
   }

--- a/_templates/component/new/components_ComponentName_react_tsconfig.build.json.ejs.t
+++ b/_templates/component/new/components_ComponentName_react_tsconfig.build.json.ejs.t
@@ -3,7 +3,7 @@ to: components/<%= h.inflection.camelize(name, false) %>/react/tsconfig.build.js
 ---
 {
   "extends": "../../../tsconfig.react.build.json",
-  "include": ["./<%= h.inflection.camelize(name, false) %>.tsx", "./index.ts", "../*.ts"],
+  "include": ["./<%= h.inflection.camelize(name, false) %>.tsx", "./index.ts", "../constants.ts"],
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "../"

--- a/_templates/component/new/components_ComponentName_react_tsconfig.build.json.ejs.t
+++ b/_templates/component/new/components_ComponentName_react_tsconfig.build.json.ejs.t
@@ -5,6 +5,7 @@ to: components/<%= h.inflection.camelize(name, false) %>/react/tsconfig.build.js
   "extends": "../../../tsconfig.react.build.json",
   "include": ["./<%= h.inflection.camelize(name, false) %>.tsx", "./index.ts", "../*.ts"],
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "../"
   }
 }

--- a/_templates/component/new/components_ComponentName_react_tsconfig.json.ejs.t
+++ b/_templates/component/new/components_ComponentName_react_tsconfig.json.ejs.t
@@ -3,5 +3,5 @@ to: components/<%= h.inflection.camelize(name, false) %>/react/tsconfig.json
 ---
 {
   "extends": "../../../tsconfig.react.json",
-  "include": ["*.tsx", "*.ts", "../../../cypress/support/*.ts"]
+  "include": ["*.tsx", "*.ts", "../*.ts", "../../../cypress/support/*.ts"]
 }

--- a/_templates/component/new/components_ComponentName_vue_ComponentName.cy.tsx.ejs.t
+++ b/_templates/component/new/components_ComponentName_vue_ComponentName.cy.tsx.ejs.t
@@ -3,10 +3,12 @@ to: components/<%= h.inflection.camelize(name, false) %>/vue/<%= h.inflection.ca
 ---
 /// <reference types="cypress" />
 import { mount } from 'cypress/vue'
+import assertions from '../assertions'
 import <%= h.inflection.camelize(name, false) %>Story from './<%= h.inflection.camelize(name, false) %>.rootstory'
 
-describe('<<%= h.inflection.camelize(name, false) %> />', () => {
-  it('renders', () => {
-    mount(<%= h.inflection.camelize(name, false) %>Story)
-  })
+describe('<<%= h.inflection.camelize(name, false) %>/>', () => {
+  function mountStory(options: Parameters<typeof <%= h.inflection.camelize(name, false) %>Story>[0] = {}) {
+    mount(() => <<%= h.inflection.camelize(name, false) %>Story {...options} />)
+  }
+  assertions(mountStory)
 })

--- a/_templates/component/new/components_ComponentName_vue_ComponentName.rootstory.tsx.ejs.t
+++ b/_templates/component/new/components_ComponentName_vue_ComponentName.rootstory.tsx.ejs.t
@@ -3,4 +3,7 @@ to: components/<%= h.inflection.camelize(name, false) %>/vue/<%= h.inflection.ca
 ---
 import <%= h.inflection.camelize(name, false) %> from './<%= h.inflection.camelize(name, false) %>.vue'
 
-export default () => <<%= h.inflection.camelize(name, false) %> id="foo" />
+export default (options: { id?: string }) => {
+  const { id = 'foo', ...rest } = options
+  return <<%= h.inflection.camelize(name, false) %> id={id} {...rest} />
+}

--- a/_templates/component/new/components_ComponentName_vue_ComponentName.vue.ejs.t
+++ b/_templates/component/new/components_ComponentName_vue_ComponentName.vue.ejs.t
@@ -9,6 +9,8 @@ to: components/<%= h.inflection.camelize(name, false) %>/vue/<%= h.inflection.ca
 </template>
 
 <script lang="ts" setup>
+import { SharedSettings } from '../constants';
+
 withDefaults(
   defineProps<{
     id: string

--- a/_templates/component/new/components_ComponentName_vue_package.json.ejs.t
+++ b/_templates/component/new/components_ComponentName_vue_package.json.ejs.t
@@ -7,7 +7,7 @@ to: components/<%= h.inflection.camelize(name, false) %>/vue/package.json
   "files": [
     "*"
   ],
-  "typings": "./dist/index.d.ts",
+  "typings": "./dist/vue/index.d.ts",
   "module": "./dist/index.es.mjs",
   "main": "./dist/index.umd.js",
   "exports": {

--- a/_templates/component/new/components_ComponentName_vue_tsconfig.build.json.ejs.t
+++ b/_templates/component/new/components_ComponentName_vue_tsconfig.build.json.ejs.t
@@ -3,7 +3,7 @@ to: components/<%= h.inflection.camelize(name, false) %>/vue/tsconfig.build.json
 ---
 {
   "extends": "../../../tsconfig.vue.json",
-  "include": ["./*.vue", "./index.ts"],
+  "include": ["./*.vue", "./index.ts", "../*.ts"],
   "compilerOptions": {
     "outDir": "dist"
   }

--- a/_templates/component/new/components_ComponentName_vue_tsconfig.build.json.ejs.t
+++ b/_templates/component/new/components_ComponentName_vue_tsconfig.build.json.ejs.t
@@ -3,7 +3,7 @@ to: components/<%= h.inflection.camelize(name, false) %>/vue/tsconfig.build.json
 ---
 {
   "extends": "../../../tsconfig.vue.json",
-  "include": ["./*.vue", "./index.ts", "../*.ts"],
+  "include": ["./*.vue", "./index.ts", "../constants.ts"],
   "compilerOptions": {
     "outDir": "dist"
   }

--- a/_templates/component/new/components_ComponentName_vue_tsconfig.json.ejs.t
+++ b/_templates/component/new/components_ComponentName_vue_tsconfig.json.ejs.t
@@ -3,5 +3,11 @@ to: components/<%= h.inflection.camelize(name, false) %>/vue/tsconfig.json
 ---
 {
   "extends": "../../../tsconfig.vue.json",
-  "include": ["*.vue", "*.ts", "*.tsx", "../../../cypress/support/*.ts"]
+  "include": [
+    "*.vue",
+    "*.ts",
+    "*.tsx",
+    "../*.ts",
+    "../../../cypress/support/*.ts"
+  ]
 }

--- a/components/Alert/vue/package.json
+++ b/components/Alert/vue/package.json
@@ -11,6 +11,10 @@
     ".": {
       "import": "./dist/index.es.mjs",
       "require": "./dist/index.umd.js"
+    },
+    "./style": {
+      "import": "./dist/style.css",
+      "require": "./dist/style.css"
     }
   },
   "scripts": {

--- a/components/root.vite.config.ts
+++ b/components/root.vite.config.ts
@@ -13,13 +13,18 @@ export default (libConfig: LibraryOptions) =>
         ...libConfig,
       },
       rollupOptions: {
-        external: ['vue', '@cypress-design/icon-registry'],
+        external: [
+          'vue',
+          '@cypress-design/icon-registry',
+          '@cypress-design/icon',
+        ],
         output: {
           // Provide global variables to use in the UMD build
           // Add external deps here
           globals: {
             vue: 'Vue',
-            '@cypress-design/icon-registry': 'IconRegistry',
+            '@cypress-design/icon-registry': 'CyIconRegistry',
+            '@cypress-design/icon': 'CyIcon',
           },
         },
       },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@vue/tsconfig": "^0.1.3",
     "axe-core": "^4.4.2",
     "concurrently": "^7.1.0",
-    "cypress": "^10.3.1",
+    "cypress": "^10.4.0",
     "cypress-axe": "^0.14.0",
     "cypress-real-events": "^1.7.0",
     "dedent": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5861,10 +5861,10 @@ cypress-real-events@^1.7.0:
   resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.7.0.tgz#ad6a78de33af3af0e6437f5c713e30691c44472c"
   integrity sha512-iyXp07j0V9sG3YClVDcvHN2DAQDgr+EjTID82uWDw6OZBlU3pXEBqTMNYqroz3bxlb0k+F74U81aZwzMNaKyew==
 
-cypress@^10.3.1:
-  version "10.3.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.3.1.tgz#7fab4ef43481c05a9a17ebe9a0ec860e15b95a19"
-  integrity sha512-As9HrExjAgpgjCnbiQCuPdw5sWKx5HUJcK2EOKziu642akwufr/GUeqL5UnCPYXTyyibvEdWT/pSC2qnGW/e5w==
+cypress@^10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.4.0.tgz#bb5b3b6588ad49eff172fecf5778cc0da2980e4e"
+  integrity sha512-OM7F8MRE01SHQRVVzunid1ZK1m90XTxYnl+7uZfIrB4CYqUDCrZEeSyCXzIbsS6qcaijVCAhqDL60SxG8N6hew==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
Make sharable constants a default for cypress components.

This change is only done for templates used by `yarn new:component`

It also shares cypress assertions by default so we run tests on both vue and react