### PR TITLE
Fix status icons types file location

### DIFF
--- a/.changeset/olive-mice-promise.md
+++ b/.changeset/olive-mice-promise.md
@@ -1,0 +1,6 @@
+---
+'@cypress-design/react-statusicon': patch
+'@cypress-design/vue-statusicon': patch
+---
+
+Fix types file location

--- a/components/StatusIcon/react/package.json
+++ b/components/StatusIcon/react/package.json
@@ -4,7 +4,7 @@
   "files": [
     "*"
   ],
-  "typings": "./dist/index.d.ts",
+  "typings": "./dist/react/index.d.ts",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.mjs",
   "exports": {

--- a/components/StatusIcon/vue/package.json
+++ b/components/StatusIcon/vue/package.json
@@ -4,7 +4,7 @@
   "files": [
     "*"
   ],
-  "typings": "./dist/index.d.ts",
+  "typings": "./dist/vue/index.d.ts",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.mjs",
   "exports": {


### PR DESCRIPTION
I'm hoping this will fix [this build failure](https://app.circleci.com/pipelines/github/cypress-io/cypress-services/21895/workflows/8435a646-b9b2-43bc-96e0-6111bfe18c7a/jobs/312072), although i'm not sure...