### PR TITLE
fix: remove prefix on svg classes

### DIFF
--- a/.changeset/remove-svg-prefix-on-classes.md
+++ b/.changeset/remove-svg-prefix-on-classes.md
@@ -1,0 +1,7 @@
+---
+'@cypress-design/icon-registry': patch
+'@cypress-design/react-icon': patch
+'@cypress-design/vue-icon': patch
+---
+
+fix: remove svg icon classes

--- a/icon-registry/svgo.config.js
+++ b/icon-registry/svgo.config.js
@@ -5,7 +5,12 @@ module.exports = {
     {
       name: 'preset-default',
     },
-    'prefixIds',
+    {
+      name: 'prefixIds',
+      params: {
+        prefixClassNames: false,
+      },
+    },
     extractBodyPlugin,
   ],
 }


### PR DESCRIPTION
> We spoke too soon.  The change you made also prefixed all the class names, so the icons that rely on having classess like icon-dark or icon-light now look like long_prefx_icon_name_icon-dark instead.  It looks like the built in plugin you used (“prefixIds”) has an undocumented parameter called prefixClassNames that you can set to false.  See code here: https://github.com/svg/svgo/blob/main/plugins/prefixIds.js#L76

Fix this and re-release