### PR TITLE
Dark mode tabs

### DIFF
--- a/.changeset/dark-tabs-variants.md
+++ b/.changeset/dark-tabs-variants.md
@@ -1,0 +1,7 @@
+---
+"@cypress-design/constants-tabs": minor
+"@cypress-design/vue-tabs": minor
+"@cypress-design/react-tabs": minor
+---
+
+Add dark variants to tabs

--- a/components/Tabs/ReadMe.md
+++ b/components/Tabs/ReadMe.md
@@ -13,6 +13,22 @@ import { IconActionPlayVideo, IconActionRecord, IconDeviceLaptop, IconGeneralCro
     { id: 'err', label: 'Errors', active:true},
     { id: 'reco', label: 'Recommendations' },
   ]"/>
+  <div class="h-[20px]"/>
+  <p>dark-small</p>
+  <Tabs variant="dark-small" :tabs="[
+    { id: 'ov', label: 'Overview', icon: IconActionPlayVideo, active: true },
+    { id: 'cl', label: 'Command Log', icon: IconActionRecord },
+    { id: 'err', label: 'Errors', iconAfter: IconSecurityLockLocked, tag: '13' },
+    { id: 'reco', label: 'Recommendations', icon: IconGeneralCrosshairs },
+  ]"/>
+  <div class="h-[24px]"/>
+  <p>dark-default</p>
+  <Tabs variant="dark-default" :tabs="[
+    { id: 'ov', label: 'Overview', icon: IconActionPlayVideo, active: true },
+    { id: 'cl', label: 'Command Log', icon: IconActionRecord },
+    { id: 'err', label: 'Errors', iconAfter: IconSecurityLockLocked, tag: '13' },
+    { id: 'reco', label: 'Recommendations', icon: IconGeneralCrosshairs },
+  ]"/>
   <div class="h-[24px]"/>
   <p>underline-small</p>
   <Tabs variant="underline-small" :tabs="[

--- a/components/Tabs/ReadMe.md
+++ b/components/Tabs/ReadMe.md
@@ -22,8 +22,8 @@ import { IconActionPlayVideo, IconActionRecord, IconDeviceLaptop, IconGeneralCro
     { id: 'reco', label: 'Recommendations', icon: IconGeneralCrosshairs },
   ]"/>
   <div class="h-[24px]"/>
-  <p>dark-default</p>
-  <Tabs variant="dark-default" :tabs="[
+  <p>dark-large</p>
+  <Tabs variant="dark-large" :tabs="[
     { id: 'ov', label: 'Overview', icon: IconActionPlayVideo, active: true },
     { id: 'cl', label: 'Command Log', icon: IconActionRecord },
     { id: 'err', label: 'Errors', iconAfter: IconSecurityLockLocked, tag: '13' },

--- a/components/Tabs/assertions.ts
+++ b/components/Tabs/assertions.ts
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-import { Tab } from './constants'
+import { variants, Tab } from './constants'
 
 const tabs = [
   { id: 'ov', label: 'Overview', active: true },
@@ -10,9 +10,18 @@ const tabs = [
 ]
 
 export default function assertions(
-  mountStory: (options?: { tabs: Tab[] }) => void
+  mountStory: (options?: {
+    tabs: Tab[]
+    variant?: keyof typeof variants
+  }) => void
 ): void {
   it('renders', () => {
     mountStory({ tabs })
+  })
+
+  Object.keys(variants).forEach((variant) => {
+    it(`renders ${variant}`, () => {
+      mountStory({ tabs, variant: variant as keyof typeof variants })
+    })
   })
 }

--- a/components/Tabs/assertions.ts
+++ b/components/Tabs/assertions.ts
@@ -19,6 +19,18 @@ export default function assertions(
     mountStory({ tabs })
   })
 
+  it('moves to tab on click', () => {
+    mountStory({ tabs })
+    cy.contains('Errors').click()
+    cy.get('[aria-selected="true"]').should('have.text', ' Errors ')
+  })
+
+  it('moves to tab on arrow press', () => {
+    mountStory({ tabs })
+    cy.contains('button', 'Overview').type('{rightArrow}{rightArrow}')
+    cy.get('[aria-selected="true"]').should('have.text', ' Errors ')
+  })
+
   Object.keys(variants).forEach((variant) => {
     it(`renders ${variant}`, () => {
       mountStory({ tabs, variant: variant as keyof typeof variants })

--- a/components/Tabs/assertions.ts
+++ b/components/Tabs/assertions.ts
@@ -15,25 +15,27 @@ export default function assertions(
     variant?: keyof typeof variants
   }) => void
 ): void {
-  it('renders', () => {
-    mountStory({ tabs })
-  })
+  describe('Tabs', { viewportHeight: 80 }, () => {
+    it('renders', () => {
+      mountStory({ tabs })
+    })
 
-  it('moves to tab on click', () => {
-    mountStory({ tabs })
-    cy.contains('Errors').click()
-    cy.get('[aria-selected="true"]').should('have.text', ' Errors ')
-  })
+    it('moves to tab on click', () => {
+      mountStory({ tabs })
+      cy.contains('Errors').click()
+      cy.get('[aria-selected="true"]').should('contain.text', 'Errors')
+    })
 
-  it('moves to tab on arrow press', () => {
-    mountStory({ tabs })
-    cy.contains('button', 'Overview').type('{rightArrow}{rightArrow}')
-    cy.get('[aria-selected="true"]').should('have.text', ' Errors ')
-  })
+    it('moves to tab on arrow press', () => {
+      mountStory({ tabs })
+      cy.contains('button', 'Overview').type('{rightArrow}{rightArrow}')
+      cy.get('[aria-selected="true"]').should('contain.text', 'Errors')
+    })
 
-  Object.keys(variants).forEach((variant) => {
-    it(`renders ${variant}`, () => {
-      mountStory({ tabs, variant: variant as keyof typeof variants })
+    Object.keys(variants).forEach((variant) => {
+      it(`renders ${variant}`, () => {
+        mountStory({ tabs, variant: variant as keyof typeof variants })
+      })
     })
   })
 }

--- a/components/Tabs/constants/package.json
+++ b/components/Tabs/constants/package.json
@@ -15,5 +15,8 @@
   "scripts": {
     "build": "tsc --project ./tsconfig.json"
   },
+  "dependencies": {
+    "@cypress-design/icon-registry": "*"
+  },
   "license": "MIT"
 }

--- a/components/Tabs/constants/src/index.ts
+++ b/components/Tabs/constants/src/index.ts
@@ -56,8 +56,6 @@ export const variants = {
     },
     icon: {
       size: '16',
-      // <wind-keep fillColor="transparent"/>
-      fillColor: 'transparent',
     } satisfies IconProps,
   },
   'dark-small': {
@@ -101,7 +99,7 @@ export const variants = {
       tag: '',
     },
     icon: {
-      size: '24',
+      size: '16',
       // <wind-keep fillColor="transparent"/>
       fillColor: 'transparent',
     } satisfies IconProps,

--- a/components/Tabs/constants/src/index.ts
+++ b/components/Tabs/constants/src/index.ts
@@ -56,6 +56,8 @@ export const variants = {
     },
     icon: {
       size: '16',
+      // <wind-keep fillColor="transparent"/>
+      fillColor: 'transparent',
     } satisfies IconProps,
   },
   'dark-small': {

--- a/components/Tabs/constants/src/index.ts
+++ b/components/Tabs/constants/src/index.ts
@@ -49,6 +49,42 @@ export const classesMap = {
       'bg-indigo-500 absolute -z-10 rounded right-0 left-0 bottom-0 top-0',
     tag: '',
   },
+  'dark-small': {
+    wrapper:
+      'p-[4px] inline-flex gap-[4px] rounded border border-gray-900 bg-gray-1000 text-gray-400 relative',
+    button:
+      'flex items-center px-[8px] h-[20px] leading-[16px] text-[12px] rounded font-medium whitespace-nowrap',
+    active: 'text-black relative z-20',
+    activeStatic: '!text-white',
+    inActive: 'hover:bg-gray-900',
+    activeMarker:
+      'absolute bottom-[4px] top-[4px] rounded duration-300 ease-in-out',
+    activeMarkerColor:
+      'bg-gray-800 filter hue-rotate-180 brightness-200 saturate-150 z-10',
+    activeMarkerBlender:
+      'z-30 bg-white mix-blend-difference pointer-events-none',
+    activeMarkerStatic:
+      'bg-gray-800 absolute -z-10 rounded right-0 left-0 bottom-0 top-0',
+    tag: '',
+  },
+  'dark-default': {
+    wrapper:
+      'p-[4px] inline-flex gap-[8px] rounded border border-gray-900 bg-gray-1000 text-gray-400 relative',
+    button:
+      'flex items-center px-[12px] h-[24px] leading-[20px] text-[14px] rounded font-medium whitespace-nowrap',
+    active: 'text-black relative z-20',
+    activeStatic: '!text-white',
+    inActive: 'hover:bg-gray-900',
+    activeMarker:
+      'absolute bottom-[4px] top-[4px] rounded duration-300 ease-in-out',
+    activeMarkerColor:
+      'bg-gray-800 filter hue-rotate-180 brightness-200 saturate-150 z-10',
+    activeMarkerBlender:
+      'z-30 bg-white mix-blend-difference pointer-events-none',
+    activeMarkerStatic:
+      'bg-gray-800 absolute -z-10 rounded right-0 left-0 bottom-0 top-0',
+    tag: '',
+  },
   'underline-small': {
     wrapper:
       'py-[4px] flex gap-[8px] border-b border-gray-100 text-gray-700 dark:text-white relative',

--- a/components/Tabs/constants/src/index.ts
+++ b/components/Tabs/constants/src/index.ts
@@ -54,15 +54,13 @@ export const classesMap = {
       'p-[4px] inline-flex gap-[4px] rounded border border-gray-900 bg-gray-1000 text-gray-400 relative',
     button:
       'flex items-center px-[8px] h-[20px] leading-[16px] text-[12px] rounded font-medium whitespace-nowrap',
-    active: 'text-black relative z-20',
-    activeStatic: '!text-white',
+    active: 'text-white relative z-20',
+    activeStatic: '',
     inActive: 'hover:bg-gray-900',
     activeMarker:
       'absolute bottom-[4px] top-[4px] rounded duration-300 ease-in-out',
-    activeMarkerColor:
-      'bg-gray-800 filter hue-rotate-180 brightness-200 saturate-150 z-10',
-    activeMarkerBlender:
-      'z-30 bg-white mix-blend-difference pointer-events-none',
+    activeMarkerColor: 'z-10 bg-gray-800',
+    activeMarkerBlender: 'z-30 mix-blend-overlay',
     activeMarkerStatic:
       'bg-gray-800 absolute -z-10 rounded right-0 left-0 bottom-0 top-0',
     tag: '',
@@ -72,15 +70,13 @@ export const classesMap = {
       'p-[4px] inline-flex gap-[8px] rounded border border-gray-900 bg-gray-1000 text-gray-400 relative',
     button:
       'flex items-center px-[12px] h-[24px] leading-[20px] text-[14px] rounded font-medium whitespace-nowrap',
-    active: 'text-black relative z-20',
-    activeStatic: '!text-white',
+    active: 'text-white relative z-20',
+    activeStatic: '',
     inActive: 'hover:bg-gray-900',
     activeMarker:
       'absolute bottom-[4px] top-[4px] rounded duration-300 ease-in-out',
-    activeMarkerColor:
-      'bg-gray-800 filter hue-rotate-180 brightness-200 saturate-150 z-10',
-    activeMarkerBlender:
-      'z-30 bg-white mix-blend-difference pointer-events-none',
+    activeMarkerColor: 'z-10 bg-gray-800',
+    activeMarkerBlender: 'z-30 mix-blend-overlay',
     activeMarkerStatic:
       'bg-gray-800 absolute -z-10 rounded right-0 left-0 bottom-0 top-0',
     tag: '',

--- a/components/Tabs/constants/src/index.ts
+++ b/components/Tabs/constants/src/index.ts
@@ -60,7 +60,7 @@ export const classesMap = {
     activeMarker:
       'absolute bottom-[4px] top-[4px] rounded duration-300 ease-in-out',
     activeMarkerColor: 'z-10 bg-gray-800',
-    activeMarkerBlender: 'z-30 mix-blend-overlay',
+    activeMarkerBlender: 'z-30 mix-blend-overlay pointer-events-none',
     activeMarkerStatic:
       'bg-gray-800 absolute -z-10 rounded right-0 left-0 bottom-0 top-0',
     tag: '',
@@ -76,7 +76,7 @@ export const classesMap = {
     activeMarker:
       'absolute bottom-[4px] top-[4px] rounded duration-300 ease-in-out',
     activeMarkerColor: 'z-10 bg-gray-800',
-    activeMarkerBlender: 'z-30 mix-blend-overlay',
+    activeMarkerBlender: 'z-30 mix-blend-overlay pointer-events-none',
     activeMarkerStatic:
       'bg-gray-800 absolute -z-10 rounded right-0 left-0 bottom-0 top-0',
     tag: '',

--- a/components/Tabs/constants/src/index.ts
+++ b/components/Tabs/constants/src/index.ts
@@ -1,3 +1,7 @@
+import type { OpenIconProps } from '@cypress-design/icon-registry'
+
+type IconProps = Omit<OpenIconProps, 'name'>
+
 export interface Tab {
   id: string
   /**
@@ -30,89 +34,124 @@ export interface Tab {
   href?: string
 }
 
-export const classesMap = {
+export const variants = {
   default: {
-    wrapper:
-      'p-[4px] inline-flex gap-[8px] rounded border border-gray-100 bg-white text-gray-700 relative',
-    button:
-      'flex items-center px-[12px] h-[24px] leading-[20px] text-[14px] rounded font-medium whitespace-nowrap',
-    active: 'text-black relative z-20',
-    activeStatic: '!text-white',
-    inActive: 'hover:bg-gray-50',
-    activeMarker:
-      'absolute bottom-[4px] top-[4px] rounded duration-300 ease-in-out',
-    activeMarkerColor:
-      'bg-indigo-500 filter hue-rotate-180 brightness-200 saturate-150 z-10',
-    activeMarkerBlender:
-      'z-30 bg-white mix-blend-difference pointer-events-none',
-    activeMarkerStatic:
-      'bg-indigo-500 absolute -z-10 rounded right-0 left-0 bottom-0 top-0',
-    tag: '',
+    classes: {
+      wrapper:
+        'p-[4px] inline-flex gap-[8px] rounded border border-gray-100 bg-white text-gray-700 relative',
+      button:
+        'flex items-center px-[12px] h-[24px] leading-[20px] text-[14px] rounded font-medium whitespace-nowrap',
+      active: 'text-black relative z-20',
+      activeStatic: '!text-white',
+      inActive: 'hover:bg-gray-50',
+      activeMarker:
+        'absolute bottom-[4px] top-[4px] rounded duration-300 ease-in-out',
+      activeMarkerColor:
+        'bg-indigo-500 filter hue-rotate-180 brightness-200 saturate-150 z-10',
+      activeMarkerBlender:
+        'z-30 bg-white mix-blend-difference pointer-events-none',
+      activeMarkerStatic:
+        'bg-indigo-500 absolute -z-10 rounded right-0 left-0 bottom-0 top-0',
+      tag: '',
+    },
+    icon: {
+      size: '16',
+      // <wind-keep fillColor="transparent"/>
+      fillColor: 'transparent',
+    } satisfies IconProps,
   },
   'dark-small': {
-    wrapper:
-      'p-[4px] inline-flex gap-[4px] rounded border border-gray-900 bg-gray-1000 text-gray-400 relative',
-    button:
-      'flex items-center px-[8px] h-[20px] leading-[16px] text-[12px] rounded font-medium whitespace-nowrap',
-    active: 'text-white relative z-20',
-    activeStatic: '',
-    inActive: 'hover:bg-gray-900',
-    activeMarker:
-      'absolute bottom-[4px] top-[4px] rounded duration-300 ease-in-out',
-    activeMarkerColor: 'z-10 bg-gray-800',
-    activeMarkerBlender: 'z-30 mix-blend-overlay pointer-events-none',
-    activeMarkerStatic:
-      'bg-gray-800 absolute -z-10 rounded right-0 left-0 bottom-0 top-0',
-    tag: '',
+    classes: {
+      wrapper:
+        'p-[4px] inline-flex gap-[4px] rounded border border-gray-900 bg-gray-1000 text-gray-400 relative',
+      button:
+        'flex items-center px-[8px] h-[20px] leading-[16px] text-[12px] rounded font-medium whitespace-nowrap',
+      active: 'text-white relative z-20',
+      activeStatic: '',
+      inActive: 'hover:bg-gray-900',
+      activeMarker:
+        'absolute bottom-[4px] top-[4px] rounded duration-300 ease-in-out',
+      activeMarkerColor: 'z-10 bg-gray-800',
+      activeMarkerBlender: 'z-30 mix-blend-overlay pointer-events-none',
+      activeMarkerStatic:
+        'bg-gray-800 absolute -z-10 rounded right-0 left-0 bottom-0 top-0',
+      tag: '',
+    },
+    icon: {
+      size: '16',
+      // <wind-keep fillColor="transparent"/>
+      fillColor: 'transparent',
+    } satisfies IconProps,
   },
-  'dark-default': {
-    wrapper:
-      'p-[4px] inline-flex gap-[8px] rounded border border-gray-900 bg-gray-1000 text-gray-400 relative',
-    button:
-      'flex items-center px-[12px] h-[24px] leading-[20px] text-[14px] rounded font-medium whitespace-nowrap',
-    active: 'text-white relative z-20',
-    activeStatic: '',
-    inActive: 'hover:bg-gray-900',
-    activeMarker:
-      'absolute bottom-[4px] top-[4px] rounded duration-300 ease-in-out',
-    activeMarkerColor: 'z-10 bg-gray-800',
-    activeMarkerBlender: 'z-30 mix-blend-overlay pointer-events-none',
-    activeMarkerStatic:
-      'bg-gray-800 absolute -z-10 rounded right-0 left-0 bottom-0 top-0',
-    tag: '',
+  'dark-large': {
+    classes: {
+      wrapper:
+        'p-[4px] inline-flex gap-[8px] rounded border border-gray-900 bg-gray-1000 text-gray-400 relative',
+      button:
+        'flex items-center px-[12px] h-[24px] leading-[20px] text-[14px] rounded font-medium whitespace-nowrap',
+      active: 'text-white relative z-20',
+      activeStatic: '',
+      inActive: 'hover:bg-gray-900',
+      activeMarker:
+        'absolute bottom-[4px] top-[4px] rounded duration-300 ease-in-out',
+      activeMarkerColor: 'z-10 bg-gray-800',
+      activeMarkerBlender: 'z-30 mix-blend-overlay pointer-events-none',
+      activeMarkerStatic:
+        'bg-gray-800 absolute -z-10 rounded right-0 left-0 bottom-0 top-0',
+      tag: '',
+    },
+    icon: {
+      size: '24',
+      // <wind-keep fillColor="transparent"/>
+      fillColor: 'transparent',
+    } satisfies IconProps,
   },
   'underline-small': {
-    wrapper:
-      'py-[4px] flex gap-[8px] border-b border-gray-100 text-gray-700 dark:text-white relative',
-    button:
-      'flex items-center px-[12px] h-[24px] leading-[20px] text-[14px] rounded font-medium whitespace-nowrap relative',
-    active: 'text-gray-900 dark:text-gray-400 z-20',
-    activeStatic: 'relative',
-    inActive:
-      'before:transition-color before:duration-300 before:absolute hover:before:bg-gray-200 before:bottom-[-6.5px] before:h-[4px] before:left-0 before:right-0 before:rounded-full',
-    activeMarker:
-      'absolute bottom-[-2.5px] h-[4px] rounded-full z-10 duration-300 ease-in-out',
-    activeMarkerColor: 'bg-indigo-500',
-    activeMarkerBlender: 'hidden',
-    activeMarkerStatic:
-      'absolute bg-indigo-500 rounded-full right-0 left-0 bottom-[-6.5px] h-[4px]',
-    tag: 'ml-[8px] px-[4px] bg-indigo-300/20 rounded text-gray-500 text-[12px] leading-[16px]',
+    classes: {
+      wrapper:
+        'py-[4px] flex gap-[8px] border-b border-gray-100 text-gray-700 dark:text-white relative',
+      button:
+        'flex items-center px-[12px] h-[24px] leading-[20px] text-[14px] rounded font-medium whitespace-nowrap relative',
+      active: 'text-gray-900 dark:text-gray-400 z-20',
+      activeStatic: 'relative',
+      inActive:
+        'before:transition-color before:duration-300 before:absolute hover:before:bg-gray-200 before:bottom-[-6.5px] before:h-[4px] before:left-0 before:right-0 before:rounded-full',
+      activeMarker:
+        'absolute bottom-[-2.5px] h-[4px] rounded-full z-10 duration-300 ease-in-out',
+      activeMarkerColor: 'bg-indigo-500',
+      activeMarkerBlender: 'hidden',
+      activeMarkerStatic:
+        'absolute bg-indigo-500 rounded-full right-0 left-0 bottom-[-6.5px] h-[4px]',
+      tag: 'ml-[8px] px-[4px] bg-indigo-300/20 rounded text-gray-500 text-[12px] leading-[16px]',
+    },
+    icon: {
+      size: '16',
+      // <wind-keep fillColor="transparent"/>
+      fillColor: 'transparent',
+    } satisfies IconProps,
   },
   'underline-large': {
-    wrapper:
-      'py-[4px] flex gap-[8px] border-b border-gray-100 text-gray-700 dark:text-white relative',
-    button:
-      'flex items-center px-[12px] h-[32px] leading-[24px] text-[16px] rounded font-medium whitespace-nowrap relative',
-    active: 'text-gray-900 dark:text-gray-400 z-20',
-    activeStatic: 'relative',
-    inActive:
-      'before:transition-color before:duration-300 before:absolute hover:before:bg-gray-200 before:bottom-[-6.5px] before:h-[4px] before:left-0 before:right-0 before:rounded-full',
-    activeMarker:
-      'absolute bottom-[-2.5px] h-[4px] rounded-full z-10 duration-300 ease-in-out',
-    activeMarkerColor: 'bg-indigo-500',
-    activeMarkerBlender: 'hidden',
-    activeMarkerStatic:
-      'absolute bg-indigo-500 rounded-full right-0 left-0 bottom-[-6.5px] h-[4px]',
-    tag: '',
+    classes: {
+      wrapper:
+        'py-[4px] flex gap-[8px] border-b border-gray-100 text-gray-700 dark:text-white relative',
+      button:
+        'flex items-center px-[12px] h-[32px] leading-[24px] text-[16px] rounded font-medium whitespace-nowrap relative',
+      active: 'text-gray-900 dark:text-gray-400 z-20',
+      activeStatic: 'relative',
+      inActive:
+        'before:transition-color before:duration-300 before:absolute hover:before:bg-gray-200 before:bottom-[-6.5px] before:h-[4px] before:left-0 before:right-0 before:rounded-full',
+      activeMarker:
+        'absolute bottom-[-2.5px] h-[4px] rounded-full z-10 duration-300 ease-in-out',
+      activeMarkerColor: 'bg-indigo-500',
+      activeMarkerBlender: 'hidden',
+      activeMarkerStatic:
+        'absolute bg-indigo-500 rounded-full right-0 left-0 bottom-[-6.5px] h-[4px]',
+      tag: '',
+    },
+    icon: {
+      size: '24',
+      // <wind-keep fillColor="transparent"/>
+      fillColor: 'transparent',
+    } satisfies IconProps,
   },
 } as const

--- a/components/Tabs/react/ReadMe.md
+++ b/components/Tabs/react/ReadMe.md
@@ -19,11 +19,13 @@ import Tabs from '@cypress-design/react-tabs'
 ```
 
 ```tsx live
+import { IconActionPlayVideo } from '@cypress-design/react-icon'
+
 export default () => (
   <Tabs
     tabs={[
       { id: 'ov', label: 'Overview', active: true },
-      { id: 'cl', label: 'Command Log' },
+      { id: 'cl', label: 'Command Log', icon: IconActionPlayVideo },
       { id: 'err', label: 'Errors', href: 'https://www.cypress.io' },
       { id: 'reco', label: 'Recommendations' },
     ]}

--- a/components/Tabs/react/Tabs.rootstory.tsx
+++ b/components/Tabs/react/Tabs.rootstory.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import Tabs from './Tabs'
-import { Tab } from '../constants'
+import { Tab, variants } from '../constants'
 
-export default (options: { tabs: Tab[] }) => {
+export default (options: { tabs: Tab[]; variant?: keyof typeof variants }) => {
   return <Tabs {...options} />
 }

--- a/components/Tabs/react/Tabs.rootstory.tsx
+++ b/components/Tabs/react/Tabs.rootstory.tsx
@@ -1,7 +1,0 @@
-import * as React from 'react'
-import Tabs from './Tabs'
-import { Tab, variants } from '../constants'
-
-export default (options: { tabs: Tab[]; variant?: keyof typeof variants }) => {
-  return <Tabs {...options} />
-}

--- a/components/Tabs/react/Tabs.tsx
+++ b/components/Tabs/react/Tabs.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import clsx from 'clsx'
-import { Tab, classesMap } from '@cypress-design/constants-tabs'
+import { Tab, variants } from '@cypress-design/constants-tabs'
 
 export interface TabsProps {
   /**
@@ -10,7 +10,7 @@ export interface TabsProps {
   /**
    * Appearance of tabs
    */
-  variant?: keyof typeof classesMap
+  variant?: keyof typeof variants
   /**
    * Callback when tab is changed
    * @param tab new tab selected
@@ -66,7 +66,10 @@ export const Tabs: React.FC<TabsProps & React.HTMLProps<HTMLDivElement>> = ({
   }
 
   const classes =
-    variant in classesMap ? classesMap[variant] : classesMap.default
+    variant in variants ? variants[variant].classes : variants.default.classes
+
+  const iconProps =
+    variant in variants ? variants[variant].icon : variants.default.icon
 
   return (
     <div role="tablist" className={classes.wrapper} {...rest}>
@@ -105,19 +108,13 @@ export const Tabs: React.FC<TabsProps & React.HTMLProps<HTMLDivElement>> = ({
               {() => {
                 const IconBefore = tab.iconBefore ?? tab.icon
                 return IconBefore ? (
-                  <IconBefore
-                    className="mr-[8px]"
-                    size={variant !== 'underline-large' ? '24' : '16'}
-                  />
+                  <IconBefore {...iconProps} className="mr-[8px]" />
                 ) : null
               }}
               {tab.label}
               {tab.tag ? <div className={classes.tag}>{tab.tag}</div> : null}
               {tab.iconAfter ? (
-                <tab.iconAfter
-                  className="ml-[8px]"
-                  size={variant !== 'underline-large' ? '24' : '16'}
-                />
+                <tab.iconAfter {...iconProps} className="ml-[8px]" />
               ) : null}
             </>
             {tab.id === activeId && !activeMarkerStyle.left ? (

--- a/components/Tabs/react/Tabs.tsx
+++ b/components/Tabs/react/Tabs.tsx
@@ -90,6 +90,7 @@ export const Tabs: React.FC<TabsProps & React.HTMLProps<HTMLDivElement>> = ({
             ])}
             ref={(el: any) => (el ? ($tab.current[index] = el) : null)}
             tabIndex={tab.id === activeId ? undefined : -1}
+            aria-selected={tab.id === activeId ? true : undefined}
             onClick={(e) => {
               if (e.ctrlKey || e.metaKey) return
               e.preventDefault()

--- a/components/Tabs/react/Tabs.tsx
+++ b/components/Tabs/react/Tabs.tsx
@@ -106,12 +106,12 @@ export const Tabs: React.FC<TabsProps & React.HTMLProps<HTMLDivElement>> = ({
             }}
           >
             <>
-              {() => {
+              {(() => {
                 const IconBefore = tab.iconBefore ?? tab.icon
                 return IconBefore ? (
                   <IconBefore {...iconProps} className="mr-[8px]" />
                 ) : null
-              }}
+              })()}
               {tab.label}
               {tab.tag ? <div className={classes.tag}>{tab.tag}</div> : null}
               {tab.iconAfter ? (

--- a/components/Tabs/react/TabsReact.cy.tsx
+++ b/components/Tabs/react/TabsReact.cy.tsx
@@ -10,7 +10,11 @@ describe('Tabs', () => {
   function mountStory(
     options: { tabs: Tab[]; variant?: keyof typeof variants } = { tabs: [] }
   ) {
-    mount(<Tabs {...options} />)
+    mount(
+      <div className="m-4">
+        <Tabs {...options} />
+      </div>
+    )
   }
   assertions(mountStory)
 })

--- a/components/Tabs/react/TabsReact.cy.tsx
+++ b/components/Tabs/react/TabsReact.cy.tsx
@@ -2,12 +2,15 @@
 
 import * as React from 'react'
 import { mount } from 'cypress/react18'
-import TabsStory from './Tabs.rootstory'
+import Tabs from './Tabs'
+import type { Tab, variants } from '../constants'
 import assertions from '../assertions'
 
 describe('Tabs', () => {
-  function mountStory(options: Parameters<typeof TabsStory>[0] = { tabs: [] }) {
-    mount(<TabsStory {...options} />)
+  function mountStory(
+    options: { tabs: Tab[]; variant?: keyof typeof variants } = { tabs: [] }
+  ) {
+    mount(<Tabs {...options} />)
   }
   assertions(mountStory)
 })

--- a/components/Tabs/vue/Tabs.rootstory.tsx
+++ b/components/Tabs/vue/Tabs.rootstory.tsx
@@ -1,6 +1,6 @@
-import { Tab } from '../constants'
 import Tabs from './Tabs.vue'
+import { Tab, variants } from '../constants'
 
-export default (options: { tabs: Tab[] }) => {
+export default (options: { tabs: Tab[]; variant?: keyof typeof variants }) => {
   return <Tabs {...options} />
 }

--- a/components/Tabs/vue/Tabs.rootstory.tsx
+++ b/components/Tabs/vue/Tabs.rootstory.tsx
@@ -1,6 +1,0 @@
-import Tabs from './Tabs.vue'
-import { Tab, variants } from '../constants'
-
-export default (options: { tabs: Tab[]; variant?: keyof typeof variants }) => {
-  return <Tabs {...options} />
-}

--- a/components/Tabs/vue/Tabs.vue
+++ b/components/Tabs/vue/Tabs.vue
@@ -101,6 +101,7 @@ const iconProps = computed(() => {
       ref="$tab"
       role="tab"
       :tabindex="tab.id === activeId ? undefined : -1"
+      :aria-selected="tab.id === activeId ? true : undefined"
       :class="[
         classes.button,
         {

--- a/components/Tabs/vue/Tabs.vue
+++ b/components/Tabs/vue/Tabs.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
-import { Tab, classesMap } from '@cypress-design/constants-tabs'
+import { Tab, variants } from '@cypress-design/constants-tabs'
 
 const props = withDefaults(
   defineProps<{
@@ -11,7 +11,7 @@ const props = withDefaults(
     /**
      * Appearance of tabs
      */
-    variant?: keyof typeof classesMap
+    variant?: keyof typeof variants
   }>(),
   {
     variant: 'default',
@@ -77,10 +77,17 @@ function navigate(shift: number) {
 }
 
 const classes = computed(() => {
-  if (props.variant in classesMap) {
-    return classesMap[props.variant]
+  if (props.variant in variants) {
+    return variants[props.variant].classes
   }
-  return classesMap.default
+  return variants.default.classes
+})
+
+const iconProps = computed(() => {
+  if (props.variant in variants) {
+    return variants[props.variant].icon
+  }
+  return variants.default.icon
 })
 </script>
 
@@ -116,16 +123,16 @@ const classes = computed(() => {
       <component
         v-if="tab.iconBefore ?? tab.icon"
         :is="tab.iconBefore ?? tab.icon"
+        v-bind="iconProps"
         class="mr-[8px]"
-        :size="props.variant === 'underline-large' ? '24' : '16'"
       />
       {{ tab.label }}
       <div v-if="tab.tag" :class="classes.tag">{{ tab.tag }}</div>
       <component
         v-if="tab.iconAfter"
         :is="tab.iconAfter"
+        v-bind="iconProps"
         class="ml-[8px]"
-        :size="props.variant === 'underline-large' ? '24' : '16'"
       />
       <div
         v-if="tab.id === activeId && !activeMarkerStyle"

--- a/components/Tabs/vue/TabsVue.cy.tsx
+++ b/components/Tabs/vue/TabsVue.cy.tsx
@@ -8,7 +8,11 @@ describe('<Tabs/>', () => {
   function mountStory(
     options: { tabs: Tab[]; variant?: keyof typeof variants } = { tabs: [] }
   ) {
-    mount(() => <Tabs {...options} />)
+    mount(() => (
+      <div class="m-4">
+        <Tabs {...options} />
+      </div>
+    ))
   }
   assertions(mountStory)
 })

--- a/components/Tabs/vue/TabsVue.cy.tsx
+++ b/components/Tabs/vue/TabsVue.cy.tsx
@@ -4,7 +4,7 @@ import assertions from '../assertions'
 import TabsStory from './Tabs.rootstory'
 
 describe('<Tabs/>', () => {
-  function mountStory(options: Parameters<typeof TabsStory>[0] = {}) {
+  function mountStory(options: Parameters<typeof TabsStory>[0] = { tabs: [] }) {
     mount(() => <TabsStory {...options} />)
   }
   assertions(mountStory)

--- a/components/Tabs/vue/TabsVue.cy.tsx
+++ b/components/Tabs/vue/TabsVue.cy.tsx
@@ -1,11 +1,14 @@
 /// <reference types="cypress" />
 import { mount } from 'cypress/vue'
 import assertions from '../assertions'
-import TabsStory from './Tabs.rootstory'
+import Tabs from './Tabs.vue'
+import type { Tab, variants } from '../constants'
 
 describe('<Tabs/>', () => {
-  function mountStory(options: Parameters<typeof TabsStory>[0] = { tabs: [] }) {
-    mount(() => <TabsStory {...options} />)
+  function mountStory(
+    options: { tabs: Tab[]; variant?: keyof typeof variants } = { tabs: [] }
+  ) {
+    mount(() => <Tabs {...options} />)
   }
   assertions(mountStory)
 })


### PR DESCRIPTION
closes #212

In the scope of Test Replay initiative we're introducing dark version of the tabs component in two different sizes.

References:
- [Figma design](https://www.figma.com/file/1WJ3GVQyMV5e7xVxPg3yID/Design-System%2C-v1.x---%40latest?node-id=12760-26631&t=lFqizbY9YMDhx8vi-4)
- [Slack thread](https://cypressio.slack.com/archives/C3WD9SGKW/p1682970681920569)

<img width="614" alt="image" src="https://user-images.githubusercontent.com/154935/236014379-ba509353-e937-4593-89e0-9b98fae6345f.png">
