### PR TITLE
Remove xl breakpoint on main

### DIFF
--- a/docs/.vitepress/theme/components/Layout.vue
+++ b/docs/.vitepress/theme/components/Layout.vue
@@ -170,7 +170,7 @@ const { frontmatter } = useData() as any
           @click="mobileMenuOpen = false"
         />
       </aside>
-      <main class="w-[800px] mx-[24px] md:mt-[24px]">
+      <main class="w-[800px] mx-[24px] min-[1420px]:mx-auto md:mt-[24px]">
         <div v-if="CommonContent" class="relative">
           <EditButton
             :key="commonPathReadme"

--- a/docs/.vitepress/theme/components/Layout.vue
+++ b/docs/.vitepress/theme/components/Layout.vue
@@ -170,7 +170,7 @@ const { frontmatter } = useData() as any
           @click="mobileMenuOpen = false"
         />
       </aside>
-      <main class="w-[800px] mx-[24px] xl:mx-auto md:mt-[24px]">
+      <main class="w-[800px] mx-[24px] md:mt-[24px]">
         <div v-if="CommonContent" class="relative">
           <EditButton
             :key="commonPathReadme"


### PR DESCRIPTION
Small issue with layout on the XL breakpoint around 1300px wide.

Before: 

![Screenshot 2023-07-18 at 16 31 29](https://github.com/cypress-io/cypress-design/assets/7366/d90a3c2c-7cf2-4e83-a1cc-505cac97f504)

After:

![Screenshot 2023-07-18 at 16 33 06](https://github.com/cypress-io/cypress-design/assets/7366/b1718551-1523-48d0-b67b-2a9bf30336de)

