### PR TITLE
fix: use activeId in tabs readme

### DIFF
--- a/components/Tabs/react/ReadMe.md
+++ b/components/Tabs/react/ReadMe.md
@@ -23,8 +23,9 @@ import { IconActionPlayVideo } from '@cypress-design/react-icon'
 
 export default () => (
   <Tabs
+    activeId='ov'
     tabs={[
-      { id: 'ov', label: 'Overview', active: true },
+      { id: 'ov', label: 'Overview' },
       { id: 'cl', label: 'Command Log', icon: IconActionPlayVideo },
       { id: 'err', label: 'Errors', href: 'https://www.cypress.io' },
       { id: 'reco', label: 'Recommendations' },


### PR DESCRIPTION
The ReadMe for tabs was at odds with the implementation. This PR fixes it :) 