### PR TITLE
[DESIGN-1854] Light tooltip - Increasing drop-shadow for two increments

### DIFF
--- a/.changeset/few-walls-sell.md
+++ b/.changeset/few-walls-sell.md
@@ -1,0 +1,6 @@
+---
+'@cypress-design/react-tooltip': minor
+'@cypress-design/vue-tooltip': minor
+---
+
+increasing drop-shadow for two increments

--- a/components/Tooltip/react/Tooltip.tsx
+++ b/components/Tooltip/react/Tooltip.tsx
@@ -147,7 +147,7 @@ export const Tooltip: React.FC<
       case 'light':
         return {
           svg: 'stroke-none fill-white',
-          block: 'text-gray-900 shadow-gray-100 border-transparent ',
+          block: 'text-gray-900 shadow-gray-300 border-transparent ',
           background: 'bg-white',
         }
       case 'dark':

--- a/components/Tooltip/vue/Tooltip.vue
+++ b/components/Tooltip/vue/Tooltip.vue
@@ -35,7 +35,7 @@ const props = withDefaults(
   }>(),
   {
     color: 'light',
-  }
+  },
 )
 
 const portalTarget: Ref<HTMLElement | null> = ref(null)
@@ -85,7 +85,7 @@ const colors = computed(() => {
     case 'light':
       return {
         svg: 'stroke-none fill-white',
-        block: 'text-gray-900 shadow-gray-100 border-transparent',
+        block: 'text-gray-900 shadow-gray-300 border-transparent',
         background: 'bg-white',
       }
     case 'dark':
@@ -105,7 +105,7 @@ watch(
     if (show.value) {
       placeTooltip()
     }
-  }
+  },
 )
 
 async function placeTooltip() {
@@ -171,7 +171,7 @@ onMounted(() => {
         placeTooltip()
       }
     },
-    { immediate: true }
+    { immediate: true },
   )
 })
 </script>


### PR DESCRIPTION
Clickup link: https://cypress.clickup.com/t/18033298/DESIGN-1854

Before:
<img width="601" alt="Screenshot 2023-09-11 at 17 45 37" src="https://github.com/cypress-io/cypress-design/assets/154935/a2d51bb7-38e4-47fc-bbef-97302448543a">


After:
<img width="609" alt="Screenshot 2023-09-11 at 18 15 49" src="https://github.com/cypress-io/cypress-design/assets/154935/f8457eb1-71d9-4237-a5bf-7e5d07aa894a">
