### PR TITLE
fix: make tabs component more accessible, export button staticclasses

### DIFF
--- a/.changeset/tab-ariaControls.md
+++ b/.changeset/tab-ariaControls.md
@@ -1,0 +1,13 @@
+---
+'@cypress-design/constants-tabs': major
+'@cypress-design/react-tabs': major
+'@cypress-design/vue-tabs': major
+'@cypress-design/react-button': patch
+'@cypress-design/vue-button': patch
+
+---
+
+- Tabs component now requires `aria-controls` prop
+- Tab `id` is now passed through as an `id` attribute on the tab
+- Inactive tabs now have `aria-selected=false`
+- Button component now exports StaticClasses

--- a/components/Button/react/index.ts
+++ b/components/Button/react/index.ts
@@ -1,6 +1,7 @@
 export { default } from './Button'
 export {
   VariantClassesTable,
+  StaticClasses,
   SizeClassesTable,
   type ButtonVariants,
 } from '@cypress-design/constants-button'

--- a/components/Button/vue/index.ts
+++ b/components/Button/vue/index.ts
@@ -2,5 +2,6 @@ export { default } from './Button.vue'
 export {
   VariantClassesTable,
   SizeClassesTable,
+  StaticClasses,
   type ButtonVariants,
 } from '@cypress-design/constants-button'

--- a/components/Tabs/ReadMe.md
+++ b/components/Tabs/ReadMe.md
@@ -3,17 +3,17 @@ import Tabs from './vue/Tabs.vue'
 import { IconActionPlayVideo, IconActionRecord, IconGeneralCrosshairs, IconSecurityLockLocked } from '@cypress-design/vue-icon'
 
 const demoTabsSmall = [
-    { id: 'ov', label: 'Overview', icon: IconActionPlayVideo, active: true },
-    { id: 'cl', label: 'Command Log', icon: IconActionRecord },
-    { id: 'err', label: 'Errors', iconAfter: IconSecurityLockLocked, tag: '13' },
-    { id: 'reco', label: 'Recommendations', icon: IconGeneralCrosshairs },
+    { id: 'ov', label: 'Overview', icon: IconActionPlayVideo, active: true, ['aria-controls']: 'tabpanel-id-1' },
+    { id: 'cl', label: 'Command Log', icon: IconActionRecord, ['aria-controls']: 'tabpanel-id-2' },
+    { id: 'err', label: 'Errors', iconAfter: IconSecurityLockLocked, tag: '13', ['aria-controls']: 'tabpanel-id-3' },
+    { id: 'reco', label: 'Recommendations', icon: IconGeneralCrosshairs, ['aria-controls']: 'tabpanel-id-4' },
   ]
 
 const demoTabsLarge = [
-    { id: 'ov', label: 'Overview', active: true },
-    { id: 'cl', label: 'Command Log' },
-    { id: 'err', label: 'Errors', tag: '13' },
-    { id: 'reco', label: 'Recommendations' },
+    { id: 'ov', label: 'Overview', active: true, ['aria-controls']: 'tabpanel-id-1' },
+    { id: 'cl', label: 'Command Log', ['aria-controls']: 'tabpanel-id-2' },
+    { id: 'err', label: 'Errors', tag: '13', ['aria-controls']: 'tabpanel-id-3' },
+    { id: 'reco', label: 'Recommendations', ['aria-controls']: 'tabpanel-id-4' },
   ]
 
 const types = ['default', 'dark-small', 'dark-large', 'underline-small', 'underline-center', 'underline-large']

--- a/components/Tabs/assertions.ts
+++ b/components/Tabs/assertions.ts
@@ -33,6 +33,7 @@ export default function assertions(
       mountStory({ tabs, activeId: 'ov' })
       cy.contains('Errors').click()
       cy.get('[aria-selected="true"]').should('contain.text', 'Errors')
+      cy.get('[aria-selected="false"]').should('have.length', 3)
     })
 
     it('moves to tab on arrow press', () => {

--- a/components/Tabs/assertions.ts
+++ b/components/Tabs/assertions.ts
@@ -3,10 +3,10 @@
 import { variants, Tab } from './constants'
 
 const tabs = [
-  { id: 'ov', label: 'Overview' },
-  { id: 'cl', label: 'Command Log' },
-  { id: 'err', label: 'Errors' },
-  { id: 'reco', label: 'Recommendations' },
+  { id: 'ov', label: 'Overview', ['aria-controls']: 'tabpanel-id-1' },
+  { id: 'cl', label: 'Command Log', ['aria-controls']: 'tabpanel-id-2' },
+  { id: 'err', label: 'Errors', ['aria-controls']: 'tabpanel-id-3' },
+  { id: 'reco', label: 'Recommendations', ['aria-controls']: 'tabpanel-id-4' },
 ]
 
 export default function assertions(
@@ -20,6 +20,13 @@ export default function assertions(
   describe('Tabs', { viewportHeight: 80 }, () => {
     it('renders', () => {
       mountStory({ tabs, activeId: 'ov' })
+      tabs.forEach((tab, i) => {
+        cy.get(`#${tab.id}`).should(
+          'have.attr',
+          'aria-controls',
+          `tabpanel-id-${i + 1}`,
+        )
+      })
     })
 
     it('moves to tab on click', () => {

--- a/components/Tabs/constants/package.json
+++ b/components/Tabs/constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cypress-design/constants-tabs",
-  "version": "1.0.0",
+  "version": "0.6.6",
   "files": [
     "*"
   ],

--- a/components/Tabs/constants/package.json
+++ b/components/Tabs/constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cypress-design/constants-tabs",
-  "version": "0.6.6",
+  "version": "1.0.0",
   "files": [
     "*"
   ],

--- a/components/Tabs/constants/src/index.ts
+++ b/components/Tabs/constants/src/index.ts
@@ -35,6 +35,7 @@ export interface Tab {
    */
   href?: string
   [key: `data-${string}`]: any
+  ['aria-controls']: string
 }
 
 export class SwitchEvent {

--- a/components/Tabs/constants/src/index.ts
+++ b/components/Tabs/constants/src/index.ts
@@ -35,6 +35,10 @@ export interface Tab {
    */
   href?: string
   [key: `data-${string}`]: any
+  /**
+   * aria-controls attribute is required for accessibility. It should be set to the id of the tab panel that this tab controls
+   * Further reading: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role
+   */
   ['aria-controls']: string
 }
 

--- a/components/Tabs/react/ReadMe.md
+++ b/components/Tabs/react/ReadMe.md
@@ -68,6 +68,26 @@ import { IconActionPlayVideo } from '@cypress-design/react-icon'
 
 export default () => {
   const [allowMove, setAllowMove] = useState(true)
+  const tabs = [
+    { id: 'ov', label: 'Overview', ['aria-controls']: 'tabpanel-id-1' },
+    {
+      id: 'cl',
+      label: 'Command Log',
+      icon: IconActionPlayVideo,
+      ['aria-controls']: 'tabpanel-id-2',
+    },
+    {
+      id: 'err',
+      label: 'Errors',
+      href: 'https://www.cypress.io',
+      ['aria-controls']: 'tabpanel-id-3',
+    },
+    {
+      id: 'reco',
+      label: 'Recommendations',
+      ['aria-controls']: 'tabpanel-id-4',
+    },
+  ]
   return (
     <>
       <fieldset>
@@ -82,16 +102,21 @@ export default () => {
       </fieldset>
       <Tabs
         activeId="ov"
-        tabs={[
-          { id: 'ov', label: 'Overview' },
-          { id: 'cl', label: 'Command Log', icon: IconActionPlayVideo },
-          { id: 'err', label: 'Errors', href: 'https://www.cypress.io' },
-          { id: 'reco', label: 'Recommendations' },
-        ]}
+        tabs={tabs}
         onSwitch={(_, e) => {
           if (!allowMove) e.preventDefault()
         }}
       />
+      {tabs.map(({ id, ...rest }, i) => (
+        <div
+          key={i}
+          role="tabpanel"
+          id={rest['aria-controls']}
+          style={{ display: activeId === tabId ? 'block' : 'none' }}
+        >
+          Tab Panel {i + 1}
+        </div>
+      ))}
     </>
   )
 }

--- a/components/Tabs/react/ReadMe.md
+++ b/components/Tabs/react/ReadMe.md
@@ -21,17 +21,45 @@ import Tabs from '@cypress-design/react-tabs'
 ```tsx live
 import { IconActionPlayVideo } from '@cypress-design/react-icon'
 
-export default () => (
-  <Tabs
-    activeId="ov"
-    tabs={[
-      { id: 'ov', label: 'Overview' },
-      { id: 'cl', label: 'Command Log', icon: IconActionPlayVideo },
-      { id: 'err', label: 'Errors', href: 'https://www.cypress.io' },
-      { id: 'reco', label: 'Recommendations' },
-    ]}
-  />
-)
+export default () => {
+  const activeId = 'ov'
+  const tabs = [
+    { id: 'ov', label: 'Overview', ['aria-controls']: 'tabpanel-id-1' },
+    {
+      id: 'cl',
+      label: 'Command Log',
+      icon: IconActionPlayVideo,
+      ['aria-controls']: 'tabpanel-id-2',
+    },
+    {
+      id: 'err',
+      label: 'Errors',
+      href: 'https://www.cypress.io',
+      ['aria-controls']: 'tabpanel-id-3',
+    },
+    {
+      id: 'reco',
+      label: 'Recommendations',
+      ['aria-controls']: 'tabpanel-id-4',
+    },
+  ]
+
+  return (
+    <div>
+      <Tabs activeId={activeId} tabs={tabs} />
+      {tabs.map(({ id, ...rest }, i) => (
+        <div
+          key={i}
+          role="tabpanel"
+          id={rest['aria-controls']}
+          style={{ display: activeId === tabId ? 'block' : 'none' }}
+        >
+          Tab Panel {i + 1}
+        </div>
+      ))}
+    </div>
+  )
+}
 ```
 
 ```tsx live

--- a/components/Tabs/react/Tabs.tsx
+++ b/components/Tabs/react/Tabs.tsx
@@ -131,6 +131,7 @@ export const Tabs: React.FC<TabsProps & React.HTMLProps<HTMLDivElement>> = ({
         return (
           <ButtonTag
             key={id}
+            id={id}
             role="tab"
             href={href}
             className={clsx([
@@ -141,10 +142,11 @@ export const Tabs: React.FC<TabsProps & React.HTMLProps<HTMLDivElement>> = ({
                 [classes.inActive]: id !== activeId,
               },
             ])}
-            // @ts-expect-error React is incapable of typing this kind of ref so we do not add a type
-            ref={(el) => (el ? ($tab.current[index] = el) : null)}
+            ref={(el: HTMLButtonElement | HTMLAnchorElement) =>
+              el ? ($tab.current[index] = el) : null
+            }
             tabIndex={id === activeId ? undefined : -1}
-            aria-selected={id === activeId ? true : undefined}
+            aria-selected={id === activeId ? true : false}
             onClick={(e) => {
               if (e.ctrlKey || e.metaKey) return
               e.preventDefault()

--- a/components/Tabs/react/Tabs.tsx
+++ b/components/Tabs/react/Tabs.tsx
@@ -126,7 +126,7 @@ export const Tabs: React.FC<TabsProps & React.HTMLProps<HTMLDivElement>> = ({
           iconAfter: IconAfter,
           label,
           tag,
-          ...dataAttr
+          ...rest
         } = tab
         return (
           <ButtonTag
@@ -142,7 +142,7 @@ export const Tabs: React.FC<TabsProps & React.HTMLProps<HTMLDivElement>> = ({
                 [classes.inActive]: id !== activeId,
               },
             ])}
-            ref={(el: HTMLButtonElement | HTMLAnchorElement) =>
+            ref={(el: HTMLButtonElement | HTMLAnchorElement | null) =>
               el ? ($tab.current[index] = el) : null
             }
             tabIndex={id === activeId ? undefined : -1}
@@ -164,7 +164,7 @@ export const Tabs: React.FC<TabsProps & React.HTMLProps<HTMLDivElement>> = ({
                 navigate(-1)
               }
             }}
-            {...dataAttr}
+            {...rest}
           >
             {renderTab ? (
               renderTab(tab)

--- a/components/Tabs/react/TabsReact.cy.tsx
+++ b/components/Tabs/react/TabsReact.cy.tsx
@@ -19,6 +19,15 @@ describe('Tabs', () => {
     mount(
       <div className="m-4">
         <Tabs {...options} />
+        {options.tabs.map((tab, i) => (
+          <div
+            key={i}
+            id={`tabpanel-id-${i + 1}`}
+            style={{ display: options.activeId === tab.id ? 'block' : 'none' }}
+          >
+            Tab Panel {i + 1}
+          </div>
+        ))}
       </div>,
     )
   }
@@ -54,7 +63,11 @@ describe('Tabs', () => {
                 Change
               </button>
             </div>
-            <div role="tabpanel" id="tabpanel-id-2">
+            <div
+              role="tabpanel"
+              id="tabpanel-id-2"
+              style={{ display: activeId === 'fa' ? 'block' : 'none' }}
+            >
               <button id="change" onClick={() => setActiveId('ia')}>
                 Change
               </button>
@@ -72,10 +85,21 @@ describe('Tabs', () => {
 
     it('renders a custom tab', () => {
       mount(
-        <Tabs
-          tabs={[{ id: 'ia', label: 'Initial Active' }]}
-          renderTab={(tab) => <div>{tab.label} - Custom Tab</div>}
-        />,
+        <div>
+          <Tabs
+            tabs={[
+              {
+                id: 'ia',
+                label: 'Initial Active',
+                ['aria-controls']: 'tabpanel-id-1',
+              },
+            ]}
+            renderTab={(tab) => <div>{tab.label} - Custom Tab</div>}
+          />
+          <div role="tabpanel" id="tabpanel-id-1">
+            Tab Panel 1
+          </div>
+        </div>,
       )
 
       cy.contains('Custom Tab').should('exist')

--- a/components/Tabs/react/TabsReact.cy.tsx
+++ b/components/Tabs/react/TabsReact.cy.tsx
@@ -22,6 +22,7 @@ describe('Tabs', () => {
         {options.tabs.map((tab, i) => (
           <div
             key={i}
+            role="tabpanel"
             id={`tabpanel-id-${i + 1}`}
             style={{ display: options.activeId === tab.id ? 'block' : 'none' }}
           >

--- a/components/Tabs/react/TabsReact.cy.tsx
+++ b/components/Tabs/react/TabsReact.cy.tsx
@@ -32,13 +32,30 @@ describe('Tabs', () => {
           <div className="m-4">
             <Tabs
               tabs={[
-                { id: 'ia', label: 'Initial Active' },
-                { id: 'fa', label: 'Final Active' },
+                {
+                  id: 'ia',
+                  label: 'Initial Active',
+                  ['aria-controls']: 'tabpanel-id-1',
+                },
+                {
+                  id: 'fa',
+                  label: 'Final Active',
+                  ['aria-controls']: 'tabpanel-id-2',
+                },
               ]}
               activeId={activeId}
             />
-            <div>
+            <div
+              role="tabpanel"
+              id="tabpanel-id-1"
+              style={{ display: activeId === 'ia' ? 'block' : 'none' }}
+            >
               <button id="change" onClick={() => setActiveId('fa')}>
+                Change
+              </button>
+            </div>
+            <div role="tabpanel" id="tabpanel-id-2">
+              <button id="change" onClick={() => setActiveId('ia')}>
                 Change
               </button>
             </div>

--- a/components/Tabs/vue/ReadMe.md
+++ b/components/Tabs/vue/ReadMe.md
@@ -21,10 +21,24 @@ import Tabs from '@cypress-design/vue-tabs'
 ```vue live
 <Tabs
   :tabs="[
-    { id: 'ov', label: 'Overview', active: true },
-    { id: 'cl', label: 'Command Log' },
-    { id: 'err', label: 'Errors', href: 'https://www.cypress.io' },
-    { id: 'reco', label: 'Recommendations' },
+    {
+      id: 'ov',
+      label: 'Overview',
+      active: true,
+      ['aria-controls']: 'tabpanel-id-1',
+    },
+    { id: 'cl', label: 'Command Log', ['aria-controls']: 'tabpanel-id-2' },
+    {
+      id: 'err',
+      label: 'Errors',
+      href: 'https://www.cypress.io',
+      ['aria-controls']: 'tabpanel-id-3',
+    },
+    {
+      id: 'reco',
+      label: 'Recommendations',
+      ['aria-controls']: 'tabpanel-id-4',
+    },
   ]"
 />
 ```
@@ -34,10 +48,28 @@ If one blocks switching
 ```vue live
 <Tabs
   :tabs="[
-    { id: 'ov', label: 'Overview', active: true },
-    { id: 'cl', label: 'Command Log' },
-    { id: 'err', label: 'Errors', href: 'https://www.cypress.io' },
-    { id: 'reco', label: 'Recommendations' },
+    {
+      id: 'ov',
+      label: 'Overview',
+      active: true,
+      ['aria-controls']: 'tabpanel-id-1',
+    },
+    {
+      id: 'cl',
+      label: 'Command Log',
+      ['aria-controls']: 'tabpanel-id-2',
+    },
+    {
+      id: 'err',
+      label: 'Errors',
+      href: 'https://www.cypress.io',
+      ['aria-controls']: 'tabpanel-id-3',
+    },
+    {
+      id: 'reco',
+      label: 'Recommendations',
+      ['aria-controls']: 'tabpanel-id-4',
+    },
   ]"
   @switch="(_, e) => e.preventDefault()"
 />

--- a/components/Tabs/vue/Tabs.vue
+++ b/components/Tabs/vue/Tabs.vue
@@ -183,7 +183,7 @@ const iconProps = computed(() => {
         icon,
         iconBefore,
         iconAfter,
-        ...dataAttr
+        ...rest
       } in tabs"
       :key="id"
       :is="href ? 'a' : 'button'"
@@ -201,7 +201,7 @@ const iconProps = computed(() => {
           [classes.inActive]: id !== activeId,
         },
       ]"
-      v-bind="dataAttr"
+      v-bind="rest"
       @click="
         (e: MouseEvent) => {
           if (e.ctrlKey || e.metaKey) return
@@ -217,7 +217,7 @@ const iconProps = computed(() => {
               icon,
               iconBefore,
               iconAfter,
-              ...dataAttr,
+              ...rest,
             },
             switchEvent,
           )
@@ -239,7 +239,7 @@ const iconProps = computed(() => {
           icon,
           iconBefore,
           iconAfter,
-          ...dataAttr,
+          ...rest,
         }"
       >
         <component

--- a/components/Tabs/vue/Tabs.vue
+++ b/components/Tabs/vue/Tabs.vue
@@ -190,8 +190,9 @@ const iconProps = computed(() => {
       :href="href"
       ref="$tab"
       role="tab"
+      :id="id"
       :tabindex="id === activeId ? undefined : -1"
-      :aria-selected="id === activeId ? true : undefined"
+      :aria-selected="id === activeId ? true : false"
       :class="[
         classes.button,
         {

--- a/components/Tabs/vue/TabsVue.cy.tsx
+++ b/components/Tabs/vue/TabsVue.cy.tsx
@@ -45,6 +45,7 @@ describe('<Tabs/>', () => {
       ))
 
       cy.get('[aria-selected="true"]').should('contain.text', 'Initial Active')
+      cy.get('[aria-selected="false"]').should('contain.text', 'Final Active')
       cy.findByRole('button', { name: 'Change' }).click()
       cy.get('[aria-selected="true"]').should('contain.text', 'Final Active')
       cy.get('#ia').should('have.attr', 'aria-controls', 'tabpanel-id-1')

--- a/components/Tabs/vue/TabsVue.cy.tsx
+++ b/components/Tabs/vue/TabsVue.cy.tsx
@@ -15,6 +15,7 @@ describe('<Tabs/>', () => {
           <div
             key={i}
             id={`tabpanel-id-${i + 1}`}
+            role="tabpanel"
             style={{ display: options.activeId === tab.id ? 'block' : 'none' }}
           >
             Tab Panel {i + 1}

--- a/components/Tabs/vue/TabsVue.cy.tsx
+++ b/components/Tabs/vue/TabsVue.cy.tsx
@@ -36,8 +36,19 @@ describe('<Tabs/>', () => {
             ]}
             activeId={activeId.value}
           />
-          <div>
+          <div
+            id="tabpanel-id-1"
+            style={{ display: activeId.value === 'ia' ? 'block' : 'none' }}
+          >
             <button id="change" onClick={() => (activeId.value = 'fa')}>
+              Change
+            </button>
+          </div>
+          <div
+            id="tabpanel-id-2"
+            style={{ display: activeId.value === 'fa' ? 'block' : 'none' }}
+          >
+            <button id="change" onClick={() => (activeId.value = 'ia')}>
               Change
             </button>
           </div>

--- a/components/Tabs/vue/TabsVue.cy.tsx
+++ b/components/Tabs/vue/TabsVue.cy.tsx
@@ -23,8 +23,16 @@ describe('<Tabs/>', () => {
         <div class="m-4">
           <Tabs
             tabs={[
-              { id: 'ia', label: 'Initial Active' },
-              { id: 'fa', label: 'Final Active' },
+              {
+                id: 'ia',
+                label: 'Initial Active',
+                ['aria-controls']: 'tabpanel-id-1',
+              },
+              {
+                id: 'fa',
+                label: 'Final Active',
+                ['aria-controls']: 'tabpanel-id-2',
+              },
             ]}
             activeId={activeId.value}
           />
@@ -39,11 +47,21 @@ describe('<Tabs/>', () => {
       cy.get('[aria-selected="true"]').should('contain.text', 'Initial Active')
       cy.findByRole('button', { name: 'Change' }).click()
       cy.get('[aria-selected="true"]').should('contain.text', 'Final Active')
+      cy.get('#ia').should('have.attr', 'aria-controls', 'tabpanel-id-1')
+      cy.get('#fa').should('have.attr', 'aria-controls', 'tabpanel-id-2')
     })
 
     it('renders a custom tab', () => {
       mount(() => (
-        <Tabs tabs={[{ id: 'ia', label: 'Initial Active' }]}>
+        <Tabs
+          tabs={[
+            {
+              id: 'ia',
+              label: 'Initial Active',
+              ['aria-controls']: 'tabpanel-id-1',
+            },
+          ]}
+        >
           {{
             tab: (tab: Tab) => <div>{tab.label} - Custom Tab</div>,
           }}

--- a/components/Tabs/vue/TabsVue.cy.tsx
+++ b/components/Tabs/vue/TabsVue.cy.tsx
@@ -11,6 +11,15 @@ describe('<Tabs/>', () => {
     mount(() => (
       <div class="m-4">
         <Tabs {...options} />
+        {options.tabs.map((tab, i) => (
+          <div
+            key={i}
+            id={`tabpanel-id-${i + 1}`}
+            style={{ display: options.activeId === tab.id ? 'block' : 'none' }}
+          >
+            Tab Panel {i + 1}
+          </div>
+        ))}
       </div>
     ))
   }

--- a/docs/.vitepress/theme/components/FrameworkSwitch.vue
+++ b/docs/.vitepress/theme/components/FrameworkSwitch.vue
@@ -39,10 +39,18 @@ const links = computed(() => [
     :tabs="links"
     @switch="(tab: Tab) => emit('switch', tab.id as any)"
   />
-  <div id="tabpanel-react" :class="framework === 'react' ? 'block' : 'hidden'">
+  <div
+    role="tabpanel"
+    id="tabpanel-react"
+    :class="framework === 'react' ? 'block' : 'hidden'"
+  >
     React Tab Panel
   </div>
-  <div id="tabpanel-vue" :class="framework === 'vue' ? 'block' : 'hidden'">
+  <div
+    role="tabpanel"
+    id="tabpanel-vue"
+    :class="framework === 'vue' ? 'block' : 'hidden'"
+  >
     Vue Tab Panel
   </div>
 </template>

--- a/docs/.vitepress/theme/components/FrameworkSwitch.vue
+++ b/docs/.vitepress/theme/components/FrameworkSwitch.vue
@@ -39,18 +39,4 @@ const links = computed(() => [
     :tabs="links"
     @switch="(tab: Tab) => emit('switch', tab.id as any)"
   />
-  <div
-    role="tabpanel"
-    id="tabpanel-react"
-    :class="framework === 'react' ? 'block' : 'hidden'"
-  >
-    React Tab Panel
-  </div>
-  <div
-    role="tabpanel"
-    id="tabpanel-vue"
-    :class="framework === 'vue' ? 'block' : 'hidden'"
-  >
-    Vue Tab Panel
-  </div>
 </template>

--- a/docs/.vitepress/theme/components/FrameworkSwitch.vue
+++ b/docs/.vitepress/theme/components/FrameworkSwitch.vue
@@ -20,12 +20,14 @@ const links = computed(() => [
     label: 'React',
     iconAfter: () => h('img', { width: 24, src: ReactIcon }),
     active: props.framework === 'react',
+    ['aria-controls']: 'tabpanel-react',
   },
   {
     id: 'vue',
     label: 'Vue',
     iconAfter: () => h('img', { width: 24, src: VueIcon }),
     active: props.framework === 'vue',
+    ['aria-controls']: 'tabpanel-vue',
   },
 ])
 </script>
@@ -37,4 +39,10 @@ const links = computed(() => [
     :tabs="links"
     @switch="(tab: Tab) => emit('switch', tab.id as any)"
   />
+  <div id="tabpanel-react" :class="framework === 'react' ? 'block' : 'hidden'">
+    React Tab Panel
+  </div>
+  <div id="tabpanel-vue" :class="framework === 'vue' ? 'block' : 'hidden'">
+    Vue Tab Panel
+  </div>
 </template>

--- a/docs/.vitepress/theme/components/Layout.vue
+++ b/docs/.vitepress/theme/components/Layout.vue
@@ -202,7 +202,11 @@ const { frontmatter } = useData() as any
               :path="routePath"
               @switch="switchFramework"
             />
-            <Content class="markdown" />
+            <Content
+              class="markdown"
+              role="tabpanel"
+              :id="`tabpanel-${framework}`"
+            />
           </div>
         </div>
       </main>

--- a/test/react-app/src/App.tsx
+++ b/test/react-app/src/App.tsx
@@ -73,7 +73,7 @@ function App() {
         />
         {Array.from({ length: 3 }).map((_, i) => (
           <div key={i} id={`tabpanel-id-${i + 1}`} style={{ display: 'none' }}>
-            <p>Tab {i + 1} content</p>
+            Tab Panel {i + 1}
           </div>
         ))}
         <Tooltip popper={<b>popper</b>}>

--- a/test/react-app/src/App.tsx
+++ b/test/react-app/src/App.tsx
@@ -53,21 +53,29 @@ function App() {
               id: 'tab1',
               href: '#tab1',
               'data-testid': 'tab1',
+              'aria-controls': 'tabpanel-id-1',
             },
             {
               label: 'Tab 2',
               id: 'tab2',
               href: '#tab2',
               'data-testid': 'tab2',
+              'aria-controls': 'tabpanel-id-2',
             },
             {
               label: 'Tab 3',
               id: 'tab3',
               href: '#tab3',
               'data-testid': 'tab3',
+              'aria-controls': 'tabpanel-id-3',
             },
           ]}
         />
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} id={`tabpanel-id-${i + 1}`} style={{ display: 'none' }}>
+            <p>Tab {i + 1} content</p>
+          </div>
+        ))}
         <Tooltip popper={<b>popper</b>}>
           <p>Tooltip content</p>
         </Tooltip>

--- a/test/react-app/src/App.tsx
+++ b/test/react-app/src/App.tsx
@@ -72,7 +72,12 @@ function App() {
           ]}
         />
         {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} id={`tabpanel-id-${i + 1}`} style={{ display: 'none' }}>
+          <div
+            role="tabpanel"
+            key={i}
+            id={`tabpanel-id-${i + 1}`}
+            style={{ display: 'none' }}
+          >
             Tab Panel {i + 1}
           </div>
         ))}


### PR DESCRIPTION
Tabs component:
- `aria-controls` is required for each tab
- `aria-selected` was `undefined` when false; now it is set to `false` 
- Existing `id` prop on the Tab is also now propagated as an attribute 

Buttons component: 
- Exports StaticClasses 