### PR TITLE
make tabs buttons transparent to make normalize unnecessary

### DIFF
--- a/.changeset/unnecessary-nomralize-tabs.md
+++ b/.changeset/unnecessary-nomralize-tabs.md
@@ -1,0 +1,7 @@
+---
+'@cypress-design/constants-tabs': minor
+'@cypress-design/react-tabs': minor
+'@cypress-design/vue-tabs': minor
+---
+
+make using normalize unnecessary

--- a/.changeset/update-constants-dependencies.md
+++ b/.changeset/update-constants-dependencies.md
@@ -1,0 +1,16 @@
+---
+'@cypress-design/react-statusicon': patch
+'@cypress-design/react-testresult': patch
+'@cypress-design/react-accordion': patch
+'@cypress-design/react-checkbox': patch
+'@cypress-design/react-docmenu': patch
+'@cypress-design/react-spinner': patch
+'@cypress-design/react-button': patch
+'@cypress-design/react-alert': patch
+'@cypress-design/react-modal': patch
+'@cypress-design/react-menu': patch
+'@cypress-design/react-tabs': patch
+'@cypress-design/react-tag': patch
+---
+
+make sure the constant packages roll up in the react components for tailwind class detection

--- a/_templates/component/new/components_ComponentName_react_package.json.ejs.t
+++ b/_templates/component/new/components_ComponentName_react_package.json.ejs.t
@@ -22,10 +22,10 @@ to: components/<%= h.inflection.camelize(name, false) %>/react/package.json
     "build:types": "tsc --project ./tsconfig.build.json"
   },
   "dependencies": {
-    "@cypress-design/constants-<%= name.toLowerCase() %>": "*",
     "clsx": "*"
   },
   "devDependencies": {
+    "@cypress-design/constants-<%= name.toLowerCase() %>": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },
   "license": "MIT"

--- a/_templates/component/new/components_ComponentName_vue_package.json.ejs.t
+++ b/_templates/component/new/components_ComponentName_vue_package.json.ejs.t
@@ -23,7 +23,7 @@ to: components/<%= h.inflection.camelize(name, false) %>/vue/package.json
     "build:types": "yarn vue-tsc --project ./tsconfig.build.json"
   },
   "devDependencies": {
-    "@cypress-design/constants-<%= name.toLowerCase() %>": "*"
+    "@cypress-design/constants-<%= name.toLowerCase() %>": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },
   "license": "MIT"

--- a/_templates/component/new/components_ComponentName_vue_package.json.ejs.t
+++ b/_templates/component/new/components_ComponentName_vue_package.json.ejs.t
@@ -22,10 +22,8 @@ to: components/<%= h.inflection.camelize(name, false) %>/vue/package.json
     "build:module": "yarn vite build",
     "build:types": "yarn vue-tsc --project ./tsconfig.build.json"
   },
-  "dependencies": {
-    "@cypress-design/constants-<%= name.toLowerCase() %>": "*"
-  },
   "devDependencies": {
+    "@cypress-design/constants-<%= name.toLowerCase() %>": "*"
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },
   "license": "MIT"

--- a/components/Accordion/react/package.json
+++ b/components/Accordion/react/package.json
@@ -20,12 +20,12 @@
     "build:types": "tsc --project ./tsconfig.build.json"
   },
   "dependencies": {
-    "@cypress-design/constants-accordion": "*",
     "@cypress-design/details-animation": "*",
     "@cypress-design/react-icon": "*",
     "clsx": "*"
   },
   "devDependencies": {
+    "@cypress-design/constants-accordion": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },
   "license": "MIT"

--- a/components/Accordion/vue/package.json
+++ b/components/Accordion/vue/package.json
@@ -21,11 +21,11 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@cypress-design/constants-accordion": "*",
     "@cypress-design/details-animation": "*",
     "@cypress-design/vue-icon": "*"
   },
   "devDependencies": {
+    "@cypress-design/constants-accordion": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   }
 }

--- a/components/Alert/react/package.json
+++ b/components/Alert/react/package.json
@@ -20,12 +20,12 @@
     "build:types": "tsc --project ./tsconfig.build.json"
   },
   "dependencies": {
-    "@cypress-design/constants-alert": "*",
     "@cypress-design/details-animation": "*",
     "@cypress-design/react-icon": "*",
     "clsx": "*"
   },
   "devDependencies": {
+    "@cypress-design/constants-alert": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*",
     "postcss": "^8.4.38",
     "rollup-plugin-postcss": "^4.0.2",

--- a/components/Alert/vue/package.json
+++ b/components/Alert/vue/package.json
@@ -24,11 +24,11 @@
     "build:types": "yarn vue-tsc --project ./tsconfig.build.json"
   },
   "dependencies": {
-    "@cypress-design/constants-alert": "*",
     "@cypress-design/details-animation": "*",
     "@cypress-design/vue-icon": "*"
   },
   "devDependencies": {
+    "@cypress-design/constants-alert": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },
   "license": "MIT"

--- a/components/Button/react/package.json
+++ b/components/Button/react/package.json
@@ -20,10 +20,10 @@
     "build:types": "tsc --project ./tsconfig.build.json"
   },
   "dependencies": {
-    "@cypress-design/constants-button": "*",
     "clsx": "*"
   },
   "devDependencies": {
+    "@cypress-design/constants-button": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },
   "license": "MIT"

--- a/components/Button/vue/package.json
+++ b/components/Button/vue/package.json
@@ -19,10 +19,8 @@
     "build:module": "yarn vite build",
     "build:types": "yarn vue-tsc --project ./tsconfig.build.json"
   },
-  "dependencies": {
-    "@cypress-design/constants-button": "*"
-  },
   "devDependencies": {
+    "@cypress-design/constants-button": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },
   "license": "MIT"

--- a/components/Checkbox/react/package.json
+++ b/components/Checkbox/react/package.json
@@ -20,11 +20,11 @@
     "build:types": "tsc --project ./tsconfig.build.json"
   },
   "dependencies": {
-    "@cypress-design/constants-checkbox": "*",
     "@cypress-design/react-icon": "*",
     "clsx": "*"
   },
   "devDependencies": {
+    "@cypress-design/constants-checkbox": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },
   "license": "MIT"

--- a/components/Checkbox/vue/package.json
+++ b/components/Checkbox/vue/package.json
@@ -20,10 +20,10 @@
     "build:types": "yarn vue-tsc --project ./tsconfig.build.json"
   },
   "dependencies": {
-    "@cypress-design/constants-checkbox": "*",
     "@cypress-design/vue-icon": "*"
   },
   "devDependencies": {
+    "@cypress-design/constants-checkbox": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },
   "license": "MIT"

--- a/components/DocMenu/react/package.json
+++ b/components/DocMenu/react/package.json
@@ -20,11 +20,11 @@
     "build:types": "tsc --project ./tsconfig.build.json"
   },
   "dependencies": {
-    "@cypress-design/constants-docmenu": "*",
     "@cypress-design/react-icon": "*",
     "clsx": "*"
   },
   "devDependencies": {
+    "@cypress-design/constants-docmenu": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },
   "license": "MIT"

--- a/components/DocMenu/vue/package.json
+++ b/components/DocMenu/vue/package.json
@@ -20,10 +20,10 @@
     "build:types": "yarn vue-tsc --project ./tsconfig.build.json"
   },
   "dependencies": {
-    "@cypress-design/constants-docmenu": "*",
     "@cypress-design/vue-icon": "*"
   },
   "devDependencies": {
+    "@cypress-design/constants-docmenu": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },
   "license": "MIT"

--- a/components/Menu/react/package.json
+++ b/components/Menu/react/package.json
@@ -19,10 +19,10 @@
     "build:types": "tsc --project ./tsconfig.build.json"
   },
   "dependencies": {
-    "@cypress-design/constants-menu": "*",
     "clsx": "*"
   },
   "devDependencies": {
+    "@cypress-design/constants-menu": "*",
     "@cypress-design/react-icon": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },

--- a/components/Menu/vue/package.json
+++ b/components/Menu/vue/package.json
@@ -19,10 +19,8 @@
     "build:module": "yarn vite build",
     "build:types": "yarn vue-tsc --project ./tsconfig.build.json"
   },
-  "dependencies": {
-    "@cypress-design/constants-menu": "*"
-  },
   "devDependencies": {
+    "@cypress-design/constants-menu": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*",
     "@cypress-design/vue-icon": "*"
   },

--- a/components/Modal/react/package.json
+++ b/components/Modal/react/package.json
@@ -19,11 +19,11 @@
     "build:types": "tsc --project ./tsconfig.build.json"
   },
   "dependencies": {
-    "@cypress-design/constants-modal": "*",
     "@cypress-design/react-icon": "*",
     "clsx": "*"
   },
   "devDependencies": {
+    "@cypress-design/constants-modal": "*",
     "@cypress-design/css": "*"
   },
   "license": "MIT"

--- a/components/Modal/vue/package.json
+++ b/components/Modal/vue/package.json
@@ -19,7 +19,7 @@
     "build:module": "yarn vite build",
     "build:types": "yarn vue-tsc --project ./tsconfig.build.json"
   },
-  "dependencies": {
+  "devDependencies": {
     "@cypress-design/constants-modal": "*",
     "@cypress-design/vue-icon": "*"
   },

--- a/components/Spinner/react/package.json
+++ b/components/Spinner/react/package.json
@@ -19,10 +19,8 @@
     "build:module": "rollup -c ./rollup.config.mjs",
     "build:types": "tsc --project ./tsconfig.build.json"
   },
-  "dependencies": {
-    "@cypress-design/constants-spinner": "*"
-  },
   "devDependencies": {
+    "@cypress-design/constants-spinner": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*",
     "postcss": "^8.4.38",
     "rollup-plugin-postcss": "^4.0.2",

--- a/components/Spinner/react/rollup.config.mjs
+++ b/components/Spinner/react/rollup.config.mjs
@@ -11,5 +11,5 @@ export default rootRollupConfig({
       use: ['sass'],
     }),
   ],
-  external: Object.keys(pkg.dependencies),
+  external: Object.keys(pkg.dependencies || {}),
 })

--- a/components/Spinner/vue/package.json
+++ b/components/Spinner/vue/package.json
@@ -37,10 +37,8 @@
     "build:module": "yarn vite build",
     "build:types": "yarn vue-tsc --project ./tsconfig.build.json"
   },
-  "dependencies": {
-    "@cypress-design/constants-spinner": "*"
-  },
   "devDependencies": {
+    "@cypress-design/constants-spinner": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },
   "license": "MIT"

--- a/components/StatusIcon/react/package.json
+++ b/components/StatusIcon/react/package.json
@@ -20,11 +20,11 @@
     "build:types": "tsc --project ./tsconfig.build.json"
   },
   "dependencies": {
-    "@cypress-design/constants-statusicon": "*",
     "@cypress-design/react-icon": "^1.1.0",
     "clsx": "*"
   },
   "devDependencies": {
+    "@cypress-design/constants-statusicon": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },
   "license": "MIT"

--- a/components/StatusIcon/vue/package.json
+++ b/components/StatusIcon/vue/package.json
@@ -20,11 +20,11 @@
     "build:types": "yarn vue-tsc --project ./tsconfig.build.json"
   },
   "dependencies": {
-    "@cypress-design/constants-statusicon": "*",
     "@cypress-design/icon-registry": "*",
     "@cypress-design/vue-icon": "*"
   },
   "devDependencies": {
+    "@cypress-design/constants-statusicon": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },
   "license": "MIT"

--- a/components/Tabs/constants/src/index.ts
+++ b/components/Tabs/constants/src/index.ts
@@ -59,7 +59,7 @@ export const variants = {
       wrapper:
         'p-[4px] inline-flex gap-[8px] rounded border border-gray-100 bg-white text-gray-700 relative',
       button:
-        'flex items-center px-[12px] h-[24px] leading-[20px] text-[14px] rounded font-medium whitespace-nowrap',
+        'flex items-center px-[12px] h-[24px] leading-[20px] text-[14px] rounded font-medium whitespace-nowrap bg-transparent border-0',
       active: 'text-black relative z-20',
       activeStatic: '!text-white',
       inActive: 'hover:bg-gray-50',
@@ -84,7 +84,7 @@ export const variants = {
       wrapper:
         'p-[4px] inline-flex gap-[4px] rounded border border-gray-900 bg-gray-1000 text-gray-400 relative',
       button:
-        'flex items-center px-[8px] h-[20px] leading-[16px] text-[12px] rounded font-medium whitespace-nowrap',
+        'flex items-center px-[8px] h-[20px] leading-[16px] text-[12px] rounded font-medium whitespace-nowrap bg-transparent border-0',
       active: 'text-white relative z-20',
       activeStatic: '',
       inActive: 'hover:bg-gray-900',
@@ -107,7 +107,7 @@ export const variants = {
       wrapper:
         'p-[4px] inline-flex gap-[8px] rounded border border-gray-900 bg-gray-1000 text-gray-400 relative',
       button:
-        'flex items-center px-[12px] h-[24px] leading-[20px] text-[14px] rounded font-medium whitespace-nowrap',
+        'flex items-center px-[12px] h-[24px] leading-[20px] text-[14px] rounded font-medium whitespace-nowrap bg-transparent border-0',
       active: 'text-white relative z-20',
       activeStatic: '',
       inActive: 'hover:bg-gray-900',
@@ -130,7 +130,7 @@ export const variants = {
       wrapper:
         'py-[4px] flex gap-[8px] border-0 border-b border-solid border-gray-100 text-gray-700 relative',
       button:
-        'flex items-center px-[12px] h-[24px] leading-[20px] text-[14px] rounded font-medium whitespace-nowrap hocus:no-underline relative',
+        'flex items-center px-[12px] h-[24px] leading-[20px] text-[14px] rounded font-medium whitespace-nowrap hocus:no-underline relative bg-transparent border-0',
       active: 'text-indigo-500 z-20',
       activeStatic: 'relative',
       inActive:
@@ -156,7 +156,7 @@ export const variants = {
       subWrapper:
         'absolute bottom-0 left-0 right-0 block h-[1px] rounded-full bg-gradient-to-r from-transparent via-gray-100 via-gray-100 via-gray-100 to-transparent',
       button:
-        'flex items-center px-[12px] h-full leading-[20px] text-[14px] rounded font-medium whitespace-nowrap hocus:no-underline relative',
+        'flex items-center px-[12px] h-full leading-[20px] text-[14px] rounded font-medium whitespace-nowrap hocus:no-underline relative bg-transparent border-0',
       active: 'text-indigo-500 z-20',
       activeStatic: 'relative',
       inActive:
@@ -180,7 +180,7 @@ export const variants = {
       wrapper:
         'py-[4px] flex gap-[8px] border-0 border-b border-solid border-gray-100 text-gray-700 relative',
       button:
-        'flex items-center px-[12px] h-[32px] leading-[24px] text-[16px] rounded font-medium whitespace-nowrap relative hocus:no-underline ',
+        'flex items-center px-[12px] h-[32px] leading-[24px] text-[16px] rounded font-medium whitespace-nowrap relative hocus:no-underline bg-transparent border-0',
       active: 'text-indigo-500 z-20',
       activeStatic: 'relative',
       inActive:

--- a/components/Tabs/constants/src/index.ts
+++ b/components/Tabs/constants/src/index.ts
@@ -72,6 +72,7 @@ export const variants = {
       activeMarkerStatic:
         'bg-indigo-500 absolute -z-10 rounded right-0 left-0 bottom-0 top-0',
       tag: 'ml-[8px] px-[4px] bg-gray-200/30 rounded text-gray-500 text-[12px] leading-[16px]',
+      tagActive: '!text-black',
     },
     icon: {
       size: '16',
@@ -95,6 +96,7 @@ export const variants = {
       activeMarkerStatic:
         'bg-gray-800 absolute -z-10 rounded right-0 left-0 bottom-0 top-0',
       tag: 'ml-[8px] px-[4px] bg-gray-200/30 rounded text-gray-200 text-[12px] leading-[16px]',
+      tagActive: '',
     },
     icon: {
       size: '16',
@@ -118,6 +120,7 @@ export const variants = {
       activeMarkerStatic:
         'bg-gray-800 absolute -z-10 rounded right-0 left-0 bottom-0 top-0',
       tag: 'ml-[8px] px-[4px] bg-gray-200/30 rounded text-gray-200 text-[12px] leading-[16px]',
+      tagActive: '',
     },
     icon: {
       size: '16',
@@ -142,6 +145,7 @@ export const variants = {
       activeMarkerStatic:
         'absolute bg-indigo-500 rounded-full right-0 left-0 bottom-[-6.5px] h-[4px]',
       tag: 'ml-[8px] px-[4px] bg-gray-200/20 rounded text-gray-500 text-[12px] leading-[16px]',
+      tagActive: '',
     },
     icon: {
       size: '16',
@@ -168,6 +172,7 @@ export const variants = {
       activeMarkerStatic:
         'absolute bg-indigo-500 rounded-full right-0 left-0 bottom-[-6.5px] h-[4px]',
       tag: 'ml-[8px] px-[4px] bg-indigo-300/20 rounded text-gray-500 text-[12px] leading-[16px]',
+      tagActive: '',
     },
     icon: {
       size: '16',
@@ -192,6 +197,7 @@ export const variants = {
       activeMarkerStatic:
         'absolute bg-indigo-500 rounded-full right-0 left-0 bottom-[-6.5px] h-[4px]',
       tag: 'ml-[8px] px-[4px] bg-gray-100/50 rounded text-gray-500',
+      tagActive: '',
     },
     icon: {
       size: '24',

--- a/components/Tabs/react/ReadMe.md
+++ b/components/Tabs/react/ReadMe.md
@@ -47,7 +47,7 @@ export default () => {
   return (
     <div>
       <Tabs activeId={activeId} tabs={tabs} />
-      {tabs.map(({ id, ...rest }, i) => (
+      {tabs.map(({ id: tabId, ...rest }, i) => (
         <div
           key={i}
           role="tabpanel"
@@ -67,6 +67,7 @@ import { useState } from 'react'
 import { IconActionPlayVideo } from '@cypress-design/react-icon'
 
 export default () => {
+  const activeId = 'ov'
   const [allowMove, setAllowMove] = useState(true)
   const tabs = [
     { id: 'ov', label: 'Overview', ['aria-controls']: 'tabpanel-id-1' },
@@ -95,19 +96,19 @@ export default () => {
           id="allow-move"
           type="checkbox"
           onClick={() => setAllowMove(!allowMove)}
-          checked={allowMove}
-          class="mr-2"
+          defaultChecked={allowMove}
+          className="mr-2"
         />
-        <label for="allow-move">allow tab move</label>
+        <label htmlFor="allow-move">allow tab move</label>
       </fieldset>
       <Tabs
-        activeId="ov"
+        activeId={activeId}
         tabs={tabs}
         onSwitch={(_, e) => {
           if (!allowMove) e.preventDefault()
         }}
       />
-      {tabs.map(({ id, ...rest }, i) => (
+      {tabs.map(({ id: tabId, ...rest }, i) => (
         <div
           key={i}
           role="tabpanel"

--- a/components/Tabs/react/Tabs.tsx
+++ b/components/Tabs/react/Tabs.tsx
@@ -177,7 +177,16 @@ export const Tabs: React.FC<TabsProps & React.HTMLProps<HTMLDivElement>> = ({
                   ) : null
                 })()}
                 {label}
-                {tag ? <div className={classes.tag}>{tag}</div> : null}
+                {tag ? (
+                  <div
+                    className={clsx(
+                      classes.tag,
+                      id === activeId ? classes.tagActive : null,
+                    )}
+                  >
+                    {tag}
+                  </div>
+                ) : null}
                 {IconAfter ? (
                   <IconAfter {...iconProps} className="ml-[8px]" />
                 ) : null}

--- a/components/Tabs/react/package.json
+++ b/components/Tabs/react/package.json
@@ -20,10 +20,10 @@
     "build:types": "tsc --project ./tsconfig.build.json"
   },
   "dependencies": {
-    "@cypress-design/constants-tabs": "*",
     "clsx": "*"
   },
   "devDependencies": {
+    "@cypress-design/constants-tabs": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },
   "license": "MIT"

--- a/components/Tabs/vue/Tabs.vue
+++ b/components/Tabs/vue/Tabs.vue
@@ -249,7 +249,12 @@ const iconProps = computed(() => {
           class="mr-[8px]"
         />
         {{ label }}
-        <div v-if="tag" :class="classes.tag">{{ tag }}</div>
+        <div
+          v-if="tag"
+          :class="{ [classes.tag]: true, [classes.tagActive]: id === activeId }"
+        >
+          {{ tag }}
+        </div>
         <component
           :is="iconAfter"
           v-if="iconAfter"

--- a/components/Tabs/vue/package.json
+++ b/components/Tabs/vue/package.json
@@ -19,10 +19,8 @@
     "build:module": "yarn vite build",
     "build:types": "yarn vue-tsc --project ./tsconfig.build.json"
   },
-  "dependencies": {
-    "@cypress-design/constants-tabs": "*"
-  },
   "devDependencies": {
+    "@cypress-design/constants-tabs": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },
   "license": "MIT"

--- a/components/Tag/react/package.json
+++ b/components/Tag/react/package.json
@@ -20,10 +20,10 @@
     "build:types": "tsc --project ./tsconfig.build.json"
   },
   "dependencies": {
-    "@cypress-design/constants-tag": "*",
     "clsx": "*"
   },
   "devDependencies": {
+    "@cypress-design/constants-tag": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },
   "license": "MIT"

--- a/components/Tag/vue/package.json
+++ b/components/Tag/vue/package.json
@@ -19,10 +19,8 @@
     "build:module": "yarn vite build",
     "build:types": "yarn vue-tsc --project ./tsconfig.build.json"
   },
-  "dependencies": {
-    "@cypress-design/constants-tag": "*"
-  },
   "devDependencies": {
+    "@cypress-design/constants-tag": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },
   "license": "MIT"

--- a/components/TestResult/constants/package.json
+++ b/components/TestResult/constants/package.json
@@ -12,7 +12,7 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "dependencies": {
+  "devDependencies": {
     "@cypress-design/constants-statusicon": "*"
   },
   "scripts": {

--- a/components/TestResult/react/package.json
+++ b/components/TestResult/react/package.json
@@ -19,12 +19,12 @@
     "build:types": "tsc --project ./tsconfig.build.json"
   },
   "dependencies": {
-    "@cypress-design/constants-testresult": "*",
     "@cypress-design/react-icon": "*",
     "@cypress-design/react-statusicon": "*",
     "clsx": "*"
   },
   "devDependencies": {
+    "@cypress-design/constants-testresult": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },
   "license": "MIT"

--- a/components/TestResult/vue/package.json
+++ b/components/TestResult/vue/package.json
@@ -20,11 +20,11 @@
     "build:types": "yarn vue-tsc --project ./tsconfig.build.json"
   },
   "dependencies": {
-    "@cypress-design/constants-testresult": "*",
     "@cypress-design/vue-icon": "*",
     "@cypress-design/vue-statusicon": "*"
   },
   "devDependencies": {
+    "@cypress-design/constants-testresult": "*",
     "@cypress-design/rollup-plugin-tailwind-keep": "*"
   },
   "license": "MIT"


### PR DESCRIPTION
This pull request includes two commits that fix the styling of tabs and add the `activeId` prop to the Tabs component. The styling changes make the tab buttons transparent and borderless. The `activeId` prop allows specifying the initially active tab. These changes improve the visual appearance and functionality of the tabs.