### PR TITLE
bump icon packages

### DIFF
--- a/.changeset/curvy-mayflies-tell.md
+++ b/.changeset/curvy-mayflies-tell.md
@@ -1,0 +1,6 @@
+---
+'@cypress-design/react-icon': minor
+'@cypress-design/vue-icon': minor
+---
+
+add technology-ui-coverage 16px icon


### PR DESCRIPTION
Forgot to bump the icon package versions in #476 so that I can use the new icon in cypress-services.