### PR TITLE
Adding square-minus icons

### DIFF
--- a/.changeset/mighty-snakes-thank.md
+++ b/.changeset/mighty-snakes-thank.md
@@ -1,0 +1,7 @@
+---
+'@cypress-design/react-icon': minor
+'@cypress-design/vue-icon': minor
+'@cypress-design/icon-registry': minor
+---
+
+Adding document-square-minus_x12 icon

--- a/.changeset/mighty-snakes-thank.md
+++ b/.changeset/mighty-snakes-thank.md
@@ -4,4 +4,4 @@
 '@cypress-design/icon-registry': minor
 ---
 
-Adding document-square-minus_x12 icon
+Adding square-minus_x12, square-minus_x16, and square-minus_x24 icons

--- a/icon-registry/icons-static/document-square-minus_x12.svg
+++ b/icon-registry/icons-static/document-square-minus_x12.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path class="icon-light" d="M1 9V3C1 1.89543 1.89543 1 3 1H9C10.1046 1 11 1.89543 11 3V9C11 10.1046 10.1046 11 9 11H3C1.89543 11 1 10.1046 1 9Z" fill="transparent" />
+  <path class="icon-dark" d="M7.66667 6H4.33333M9 1H3C1.89543 1 1 1.89543 1 3V9C1 10.1046 1.89543 11 3 11H9C10.1046 11 11 10.1046 11 9V3C11 1.89543 10.1046 1 9 1Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/icon-registry/icons-static/document-square-minus_x12.svg
+++ b/icon-registry/icons-static/document-square-minus_x12.svg
@@ -1,4 +1,0 @@
-<svg viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path class="icon-light" d="M1 9V3C1 1.89543 1.89543 1 3 1H9C10.1046 1 11 1.89543 11 3V9C11 10.1046 10.1046 11 9 11H3C1.89543 11 1 10.1046 1 9Z" fill="transparent" />
-  <path class="icon-dark" d="M7.66667 6H4.33333M9 1H3C1.89543 1 1 1.89543 1 3V9C1 10.1046 1.89543 11 3 11H9C10.1046 11 11 10.1046 11 9V3C11 1.89543 10.1046 1 9 1Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/icon-registry/icons-static/square-minus_x12.svg
+++ b/icon-registry/icons-static/square-minus_x12.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M1 9V3C1 1.89543 1.89543 1 3 1H9C10.1046 1 11 1.89543 11 3V9C11 10.1046 10.1046 11 9 11H3C1.89543 11 1 10.1046 1 9Z" fill="transparent" class="icon-light" />
+  <path d="M7.66667 6H4.33333M9 1H3C1.89543 1 1 1.89543 1 3V9C1 10.1046 1.89543 11 3 11H9C10.1046 11 11 10.1046 11 9V3C11 1.89543 10.1046 1 9 1Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon-dark" />
+</svg>

--- a/icon-registry/icons-static/square-minus_x16.svg
+++ b/icon-registry/icons-static/square-minus_x16.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M2 12V4C2 2.89543 2.89543 2 4 2H12C13.1046 2 14 2.89543 14 4V12C14 13.1046 13.1046 14 12 14H4C2.89543 14 2 13.1046 2 12Z" fill="transparent" class="icon-light" />
+  <path d="M10 8H6M12 2H4C2.89543 2 2 2.89543 2 4V12C2 13.1046 2.89543 14 4 14H12C13.1046 14 14 13.1046 14 12V4C14 2.89543 13.1046 2 12 2Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon-dark" />
+</svg>

--- a/icon-registry/icons-static/square-minus_x24.svg
+++ b/icon-registry/icons-static/square-minus_x24.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M3 18V6C3 4.34315 4.34315 3 6 3H18C19.6569 3 21 4.34315 21 6V18C21 19.6569 19.6569 21 18 21H6C4.34315 21 3 19.6569 3 18Z" fill="transparent" class="icon-light" />
+  <path d="M16 12H8M18 3H6C4.34315 3 3 4.34315 3 6V18C3 19.6569 4.34315 21 6 21H18C19.6569 21 21 19.6569 21 18V6C21 4.34315 19.6569 3 18 3Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon-dark"/>
+</svg>


### PR DESCRIPTION
Adding icon as seen in Figma here: https://www.figma.com/design/zVWa3fJtO0EWZ5FEhqtCRL/Branch-Review%2C-v1.1---%40latest?t=xcmiNHxq0O0NXmJc-0

Wasn't sure if bundling the red color by default would be expected/desirable - happy to tweak this if so.

![Screen Shot 2025-01-07 at 5 00 15 PM](https://github.com/user-attachments/assets/141be4ab-aea8-4914-89ce-38b6af8b096e)
