### PR TITLE
fix: update button constants for button

### DIFF
--- a/.changeset/great-toes-beg.md
+++ b/.changeset/great-toes-beg.md
@@ -1,0 +1,7 @@
+---
+'@cypress-design/constants-button': minor
+'@cypress-design/react-button': minor
+'@cypress-design/vue-button': minor
+---
+
+update button constants for button


### PR DESCRIPTION
Button constants updates form the last version was not release with the last button release.

To replicate this issue, install the latest `@cypress-design/react-button` and try using the `outline-red` variant on a button. You will see a typescript typing error.