### PR TITLE
Adding outline-orange-dark and outline-orange-light buttons

### DIFF
--- a/.changeset/metal-hotels-learn.md
+++ b/.changeset/metal-hotels-learn.md
@@ -1,0 +1,5 @@
+---
+'@cypress-design/constants-button': minor
+---
+
+Adding outline-orange-dark and outline-orange-light buttons

--- a/.changeset/rotten-gifts-refuse.md
+++ b/.changeset/rotten-gifts-refuse.md
@@ -1,0 +1,6 @@
+---
+'@cypress-design/react-button': minor
+'@cypress-design/vue-button': minor
+---
+
+react-button and vue-button packages

--- a/components/Button/constants/src/index.ts
+++ b/components/Button/constants/src/index.ts
@@ -24,6 +24,10 @@ export const CssVariantClassesTable = {
     'text-gray-700 border-gray-100 hocus:border-gray-200 disabled:border-gray-100 disabled:hocus:shadow-none hocus:shadow-gray-50 disabled:text-gray-300 focus:ring-gray-200',
   'outline-dark':
     'text-white border-white/20 hocus:border-white/60 disabled:hocus:shadow-none hocus:shadow-white/20 disabled:border-white/20 disabled:hover:border-white/20 disabled:text-white/50 focus:ring-gray-200',
+  'outline-orange-dark':
+    'border-orange-500 text-orange-500 disabled:hocus:shadow-none hocus:shadow-orange-100 disabled:text-gray-500 focus:ring-orange-500',
+  'outline-orange-light':
+    'border-orange-200 text-orange-500 disabled:hocus:shadow-none hocus:shadow-orange-50 disabled:text-gray-500 focus:ring-orange-400',
   'outline-disabled':
     'text-gray-500 border-gray-100 hover:shadow-none bg-white',
   // light variants


### PR DESCRIPTION
Preview: 
<img width="444" alt="image" src="https://github.com/user-attachments/assets/66244977-963d-4830-ab2f-01b8f116a0d2" />


Design use case:
![image](https://github.com/user-attachments/assets/6b0f3290-72f5-4db7-a50c-243f0b26e025)
