### PR TITLE
Adding red-dark-mode and outline-red-dark-mode buttons

### DIFF
--- a/.changeset/clean-plants-change.md
+++ b/.changeset/clean-plants-change.md
@@ -1,0 +1,7 @@
+---
+'@cypress-design/constants-button': minor
+'@cypress-design/react-button': minor
+'@cypress-design/vue-button': minor
+---
+
+Adding outline-red-dark mode and red-dark-mode buttons

--- a/.changeset/clean-plants-change.md
+++ b/.changeset/clean-plants-change.md
@@ -4,4 +4,4 @@
 '@cypress-design/vue-button': minor
 ---
 
-Adding outline-red-dark mode and red-dark-mode buttons
+Adding outline-red-dark-mode, red-dark-mode and ouline-jade-dark-mode buttons

--- a/components/Button/constants/src/index.ts
+++ b/components/Button/constants/src/index.ts
@@ -16,16 +16,12 @@ export const CssVariantClassesTable = {
     'text-purple-500 border-purple-500 disabled:hocus:shadow-none hocus:shadow-purple-100 disabled:text-gray-500 focus:ring-purple-600',
   'outline-red':
     'text-red-500 border-red-500 disabled:hocus:shadow-none hocus:shadow-red-100 disabled:text-gray-500 focus:ring-red-600',
-  'outline-red-dark-mode':
-    'text-red-400 border-red-400 disabled:hocus:shadow-none hocus:shadow-red-300/35 disabled:text-gray-700 disabled:border-white/20 focus:ring-red-600',
   'outline-gray-dark':
     'text-gray-1000 border-gray-1000 disabled:hocus:shadow-none hocus:shadow-gray-100 disabled:text-gray-500 focus:ring-gray-1000',
   'outline-light':
     'text-indigo-500 border-gray-100 hocus:border-gray-200 disabled:border-gray-100 disabled:hocus:shadow-none hocus:shadow-gray-50 disabled:text-gray-500 focus:ring-gray-200',
   'outline-gray-light':
     'text-gray-700 border-gray-100 hocus:border-gray-200 disabled:border-gray-100 disabled:hocus:shadow-none hocus:shadow-gray-50 disabled:text-gray-300 focus:ring-gray-200',
-  'outline-dark':
-    'text-white border-white/20 hocus:border-white/60 disabled:hocus:shadow-none hocus:shadow-white/20 disabled:border-white/20 disabled:hover:border-white/20 disabled:text-white/50 focus:ring-gray-200',
   'outline-orange-dark':
     'border-orange-500 text-orange-500 disabled:hocus:shadow-none hocus:shadow-orange-100 disabled:text-gray-500 focus:ring-orange-500',
   'outline-orange-light':
@@ -48,12 +44,19 @@ export const CssVariantClassesTable = {
     'text-white bg-purple-500 border-purple-500 disabled:hocus:shadow-none hocus:shadow-purple-100 focus:bg-purple-600 focus:border-purple-600 focus:ring-transparent',
   'red-dark':
     'text-white bg-red-500 border-red-500 disabled:hocus:shadow-none hocus:shadow-red-100 focus:bg-red-600 focus:border-red-600 focus:ring-transparent',
-  'red-dark-mode':
-    'text-white bg-red-500 border-red-500 disabled:hocus:shadow-none disabled:bg-gray-1000 disabled:text-gray-800 disabled:border-none hocus:shadow-red-400/40 disabled:mix-blend-screen focus:bg-red-600 focus:border-red-600 focus:ring-transparent',
   'gray-dark':
     'text-white bg-gray-800 border-gray-800 disabled:hocus:shadow-none hocus:shadow-gray-100 focus:bg-gray-900 focus:border-gray-900 focus:ring-transparent',
   'gray-darkest':
     'text-white bg-gray-1000 border-gray-1000 disabled:hocus:shadow-none hocus:shadow-gray-100 focus:bg-gray-900 focus:border-gray-900 focus:ring-transparent',
+  // Dark mode
+  'outline-red-dark-mode':
+    'text-red-400 border-red-400 disabled:hocus:shadow-none hocus:shadow-red-300/35 disabled:text-gray-700 disabled:border-white/20 focus:ring-red-600',
+  'outline-jade-dark-mode':
+    'text-jade-400 border-jade-400 disabled:hocus:shadow-none hocus:shadow-jade-300/35 disabled:text-gray-700 disabled:border-white/20 focus:ring-jade-600',
+  'outline-dark':
+    'text-white border-white/20 hocus:border-white/60 disabled:hocus:shadow-none hocus:shadow-white/20 disabled:border-white/20 disabled:hover:border-white/20 disabled:text-white/50 focus:ring-gray-200',
+  'red-dark-mode':
+    'text-white bg-red-500 border-red-500 disabled:hocus:shadow-none disabled:bg-gray-1000 disabled:text-gray-800 disabled:border-none hocus:shadow-red-400/40 disabled:mix-blend-screen focus:bg-red-600 focus:border-red-600 focus:ring-transparent',
 } as const
 
 export const DefaultVariant: keyof typeof CssVariantClassesTable = 'indigo-dark'

--- a/components/Button/constants/src/index.ts
+++ b/components/Button/constants/src/index.ts
@@ -16,6 +16,8 @@ export const CssVariantClassesTable = {
     'text-purple-500 border-purple-500 disabled:hocus:shadow-none hocus:shadow-purple-100 disabled:text-gray-500 focus:ring-purple-600',
   'outline-red':
     'text-red-500 border-red-500 disabled:hocus:shadow-none hocus:shadow-red-100 disabled:text-gray-500 focus:ring-red-600',
+  'outline-red-dark-mode':
+    'text-red-400 border-red-400 disabled:hocus:shadow-none hocus:shadow-red-300/35 disabled:text-gray-700 disabled:border-white/20 focus:ring-red-600',
   'outline-gray-dark':
     'text-gray-1000 border-gray-1000 disabled:hocus:shadow-none hocus:shadow-gray-100 disabled:text-gray-500 focus:ring-gray-1000',
   'outline-light':
@@ -46,6 +48,8 @@ export const CssVariantClassesTable = {
     'text-white bg-purple-500 border-purple-500 disabled:hocus:shadow-none hocus:shadow-purple-100 focus:bg-purple-600 focus:border-purple-600 focus:ring-transparent',
   'red-dark':
     'text-white bg-red-500 border-red-500 disabled:hocus:shadow-none hocus:shadow-red-100 focus:bg-red-600 focus:border-red-600 focus:ring-transparent',
+  'red-dark-mode':
+    'text-white bg-red-500 border-red-500 disabled:hocus:shadow-none disabled:bg-gray-1000 disabled:text-gray-800 disabled:border-none hocus:shadow-red-400/40 disabled:mix-blend-screen focus:bg-red-600 focus:border-red-600 focus:ring-transparent',
   'gray-dark':
     'text-white bg-gray-800 border-gray-800 disabled:hocus:shadow-none hocus:shadow-gray-100 focus:bg-gray-900 focus:border-gray-900 focus:ring-transparent',
   'gray-darkest':

--- a/components/Button/react/Button.rootstory.tsx
+++ b/components/Button/react/Button.rootstory.tsx
@@ -17,7 +17,12 @@ export default ({
             key={variant}
             className={clsx(
               'flex flex-col items-center gap-3 justify-center mt-4 p-2',
-              { 'bg-gray-1000 text-white': variant === 'outline-dark' },
+              {
+                'bg-gray-1000 text-white':
+                  variant === 'outline-dark' ||
+                  variant === 'outline-red-dark-mode' ||
+                  variant === 'red-dark-mode',
+              },
             )}
           >
             <h3 className="text-right">{variant}</h3>
@@ -28,8 +33,15 @@ export default ({
                   <div key={size} className="flex items-center justify-center">
                     <span
                       className={clsx('text-sm mr-4', {
-                        'text-gray-300': variant === 'outline-dark',
-                        'text-gray-700': variant !== 'outline-dark',
+                        'text-gray-300':
+                          variant === 'outline-dark' ||
+                          variant === 'outline-red-dark-mode' ||
+                          variant === 'red-dark-mode',
+                        'text-gray-700': ![
+                          'outline-dark',
+                          'outline-red-dark-mode',
+                          'red-dark-mode',
+                        ].includes(variant),
                       })}
                     >
                       {size}

--- a/components/Button/react/Button.rootstory.tsx
+++ b/components/Button/react/Button.rootstory.tsx
@@ -21,6 +21,7 @@ export default ({
                 'bg-gray-1000 text-white':
                   variant === 'outline-dark' ||
                   variant === 'outline-red-dark-mode' ||
+                  variant === 'outline-jade-dark-mode' ||
                   variant === 'red-dark-mode',
               },
             )}
@@ -36,10 +37,12 @@ export default ({
                         'text-gray-300':
                           variant === 'outline-dark' ||
                           variant === 'outline-red-dark-mode' ||
+                          variant === 'outline-jade-dark-mode' ||
                           variant === 'red-dark-mode',
                         'text-gray-700': ![
                           'outline-dark',
                           'outline-red-dark-mode',
+                          'outline-jade-dark-mode',
                           'red-dark-mode',
                         ].includes(variant),
                       })}

--- a/components/Button/react/ReadMe.md
+++ b/components/Button/react/ReadMe.md
@@ -67,12 +67,14 @@ export default () => {
             backgroundColor:
               variant === 'outline-dark' ||
               variant === 'outline-red-dark-mode' ||
+              variant === 'outline-jade-dark-mode' ||
               variant === 'red-dark-mode'
                 ? '#1a202c'
                 : 'white',
             color:
               variant === 'outline-dark' ||
               variant === 'outline-red-dark-mode' ||
+              variant === 'outline-jade-dark-mode' ||
               variant === 'red-dark-mode'
                 ? 'white'
                 : 'black',

--- a/components/Button/react/ReadMe.md
+++ b/components/Button/react/ReadMe.md
@@ -64,8 +64,18 @@ export default () => {
           key={variant}
           className="px-[8px] py-[12px] flex flex-col items-center gap-[16px] rounded min-w-[180px]"
           style={{
-            backgroundColor: variant === 'outline-dark' ? '#1a202c' : 'white',
-            color: variant === 'outline-dark' ? 'white' : 'black',
+            backgroundColor:
+              variant === 'outline-dark' ||
+              variant === 'outline-red-dark-mode' ||
+              variant === 'red-dark-mode'
+                ? '#1a202c'
+                : 'white',
+            color:
+              variant === 'outline-dark' ||
+              variant === 'outline-red-dark-mode' ||
+              variant === 'red-dark-mode'
+                ? 'white'
+                : 'black',
           }}
         >
           {variant}

--- a/components/Button/vue/Button.rootstory.tsx
+++ b/components/Button/vue/Button.rootstory.tsx
@@ -18,6 +18,7 @@ export default ({
                 'bg-gray-1000 text-white':
                   variant === 'outline-dark' ||
                   variant === 'outline-red-dark-mode' ||
+                  variant === 'outline-jade-dark-mode' ||
                   variant === 'red-dark-mode',
               },
             )}
@@ -33,10 +34,12 @@ export default ({
                         'text-gray-300':
                           variant === 'outline-dark' ||
                           variant === 'outline-red-dark-mode' ||
+                          variant === 'outline-jade-dark-mode' ||
                           variant === 'red-dark-mode',
                         'text-gray-700': ![
                           'outline-dark',
                           'outline-red-dark-mode',
+                          'outline-jade-dark-mode',
                           'red-dark-mode',
                         ].includes(variant),
                       })}

--- a/components/Button/vue/Button.rootstory.tsx
+++ b/components/Button/vue/Button.rootstory.tsx
@@ -14,7 +14,12 @@ export default ({
           <div
             class={clsx(
               'flex flex-col items-center gap-3 justify-center mt-4 p-2',
-              { 'bg-gray-1000 text-white': variant === 'outline-dark' },
+              {
+                'bg-gray-1000 text-white':
+                  variant === 'outline-dark' ||
+                  variant === 'outline-red-dark-mode' ||
+                  variant === 'red-dark-mode',
+              },
             )}
           >
             <h3 class="text-right">{variant}</h3>
@@ -25,8 +30,15 @@ export default ({
                   <div class="flex items-center justify-center">
                     <span
                       class={clsx('text-sm mr-4', {
-                        'text-gray-300': variant === 'outline-dark',
-                        'text-gray-700': variant !== 'outline-dark',
+                        'text-gray-300':
+                          variant === 'outline-dark' ||
+                          variant === 'outline-red-dark-mode' ||
+                          variant === 'red-dark-mode',
+                        'text-gray-700': ![
+                          'outline-dark',
+                          'outline-red-dark-mode',
+                          'red-dark-mode',
+                        ].includes(variant),
                       })}
                     >
                       {size}

--- a/components/Button/vue/ReadMe.md
+++ b/components/Button/vue/ReadMe.md
@@ -70,10 +70,12 @@ import {
         'bg-gray-1000 text-white':
           variant === 'outline-dark' ||
           variant === 'outline-red-dark-mode' ||
+          variant === 'outline-jade-dark-mode' ||
           variant === 'red-dark-mode',
         'bg-white text-gray-900': ![
           'outline-dark',
           'outline-red-dark-mode',
+          'outline-jade-dark-mode',
           'red-dark-mode',
         ].includes(variant),
       }"

--- a/components/Button/vue/ReadMe.md
+++ b/components/Button/vue/ReadMe.md
@@ -67,8 +67,15 @@ import {
       v-for="(_, variant) in VariantClassesTable"
       class="p-[8px] py-[12px] flex flex-col items-center gap-[16px] rounded min-w-[180px]"
       :class="{
-        'bg-gray-1000 text-white': variant === 'outline-dark',
-        'bg-white text-gray-900': variant !== 'outline-dark',
+        'bg-gray-1000 text-white':
+          variant === 'outline-dark' ||
+          variant === 'outline-red-dark-mode' ||
+          variant === 'red-dark-mode',
+        'bg-white text-gray-900': ![
+          'outline-dark',
+          'outline-red-dark-mode',
+          'red-dark-mode',
+        ].includes(variant),
       }"
     >
       {{ variant }}


### PR DESCRIPTION
Preview:
<img width="198" alt="image" src="https://github.com/user-attachments/assets/a3628eb7-e8b2-4d0d-b80b-2ab0e487595a" />
<img width="204" alt="image" src="https://github.com/user-attachments/assets/b3625d96-1019-442f-b061-e39bc00ef141" />


Buttons are previewed on a dark background which indicates that they are dark mode buttons.

Currently we're adding these buttons as new button variants.

In the future we will introduce prop `theme` with values inherit, light and dark. This will enable us to decrease number of variants, but will also require refactoring.