### PR TITLE
Buttons fix: disabled states

### DIFF
--- a/.changeset/famous-cups-nail.md
+++ b/.changeset/famous-cups-nail.md
@@ -1,0 +1,7 @@
+---
+'@cypress-design/constants-button': minor
+'@cypress-design/react-button': minor
+'@cypress-design/vue-button': minor
+---
+
+Updating disabled states for buttons: outline-indigo, outline-purple, outline-red, outline-gray-dark, outline-orange-dark, outline-orange-light

--- a/components/Button/constants/src/index.ts
+++ b/components/Button/constants/src/index.ts
@@ -11,21 +11,21 @@ export const CssVariantClassesTable = {
   disabled: 'text-gray-500 bg-gray-100 border-gray-100 hover:shadow-none',
   // outline variants
   'outline-indigo':
-    'border-indigo-500 text-indigo-500 disabled:hocus:shadow-none hocus:shadow-indigo-300/[.35] disabled:text-gray-500 focus:ring-indigo-600',
+    'border-indigo-500 text-indigo-500 disabled:hocus:shadow-none hocus:shadow-indigo-300/[.35] disabled:text-gray-500 disabled:border-gray-100 focus:ring-indigo-600',
   'outline-purple':
-    'text-purple-500 border-purple-500 disabled:hocus:shadow-none hocus:shadow-purple-100 disabled:text-gray-500 focus:ring-purple-600',
+    'text-purple-500 border-purple-500 disabled:hocus:shadow-none hocus:shadow-purple-100 disabled:text-gray-500 disabled:border-gray-100 focus:ring-purple-600',
   'outline-red':
-    'text-red-500 border-red-500 disabled:hocus:shadow-none hocus:shadow-red-100 disabled:text-gray-500 focus:ring-red-600',
+    'text-red-500 border-red-500 disabled:hocus:shadow-none hocus:shadow-red-100 disabled:text-gray-500 disabled:border-gray-100 focus:ring-red-600',
   'outline-gray-dark':
-    'text-gray-1000 border-gray-1000 disabled:hocus:shadow-none hocus:shadow-gray-100 disabled:text-gray-500 focus:ring-gray-1000',
+    'text-gray-1000 border-gray-1000 disabled:hocus:shadow-none hocus:shadow-gray-100 disabled:text-gray-500 disabled:border-gray-100 focus:ring-gray-1000',
   'outline-light':
     'text-indigo-500 border-gray-100 hocus:border-gray-200 disabled:border-gray-100 disabled:hocus:shadow-none hocus:shadow-gray-50 disabled:text-gray-500 focus:ring-gray-200',
   'outline-gray-light':
     'text-gray-700 border-gray-100 hocus:border-gray-200 disabled:border-gray-100 disabled:hocus:shadow-none hocus:shadow-gray-50 disabled:text-gray-300 focus:ring-gray-200',
   'outline-orange-dark':
-    'border-orange-500 text-orange-500 disabled:hocus:shadow-none hocus:shadow-orange-100 disabled:text-gray-500 focus:ring-orange-500',
+    'border-orange-500 text-orange-500 disabled:hocus:shadow-none hocus:shadow-orange-100 disabled:text-gray-500 disabled:border-gray-100 focus:ring-orange-500',
   'outline-orange-light':
-    'border-orange-200 text-orange-500 disabled:hocus:shadow-none hocus:shadow-orange-50 disabled:text-gray-500 focus:ring-orange-400',
+    'border-orange-200 text-orange-500 disabled:hocus:shadow-none hocus:shadow-orange-50 disabled:text-gray-500 disabled:border-gray-100 focus:ring-orange-400',
   'outline-disabled':
     'text-gray-500 border-gray-100 hover:shadow-none bg-white',
   // light variants

--- a/components/Button/react/ReadMe.md
+++ b/components/Button/react/ReadMe.md
@@ -51,6 +51,8 @@ export default () => (
 
 ## Possible variants
 
+Variants and their available sizes plus styles when `disabled` is set to `true` (represented as 🚫).
+
 ```tsx live
 import {
   default as Button,
@@ -93,6 +95,12 @@ export default () => {
               </Button>
             </div>
           ))}
+          <div key={variant} className="flex gap-[8px] items-center">
+            🚫
+            <Button variant={variant} size="48" disabled="true">
+              Button
+            </Button>
+          </div>
         </div>
       ))}
     </div>


### PR DESCRIPTION
Updating disabled states for buttons: outline-indigo, outline-purple, outline-red, outline-gray-dark, outline-orange-dark, outline-orange-light

outline-indigo
<img width="216" alt="image" src="https://github.com/user-attachments/assets/cd68b660-7672-4c96-858c-c3607177408b" />
<img width="211" alt="image" src="https://github.com/user-attachments/assets/24026e93-7457-4d23-b074-a89985ce481f" />

outline-red
<img width="207" alt="image" src="https://github.com/user-attachments/assets/56e90ce1-0387-4fa5-b88d-a66d2cb9b4a6" />
<img width="199" alt="image" src="https://github.com/user-attachments/assets/156ad947-8ae1-4133-9d63-f9aeca89194d" />

outline-gray-dark
<img width="190" alt="image" src="https://github.com/user-attachments/assets/40c0390e-7dee-4e62-a513-1dbe5bf313d5" />
<img width="197" alt="image" src="https://github.com/user-attachments/assets/dbb17502-e927-495a-8998-0d31af47da12" />

outline-orange-dark
<img width="206" alt="image" src="https://github.com/user-attachments/assets/ee799c9c-6bfb-426c-b480-f042bff2cafc" />
<img width="198" alt="image" src="https://github.com/user-attachments/assets/7af4594a-09e0-479e-b308-d6e8278b3267" />

outline-orange-light
<img width="199" alt="image" src="https://github.com/user-attachments/assets/ed2eaf9a-9796-4128-bc27-7e98e3452418" />
<img width="198" alt="image" src="https://github.com/user-attachments/assets/bbbcc2b6-f3d7-4364-bc6c-84f67bdd52e1" />

