### PR TITLE
feat: add chevron-right and chevron-left icons for small, medium, and large for all sizes

### DIFF
--- a/.changeset/healthy-beds-count.md
+++ b/.changeset/healthy-beds-count.md
@@ -1,0 +1,7 @@
+---
+'@cypress-design/icon-registry': minor
+'@cypress-design/react-icon': minor
+'@cypress-design/vue-icon': minor
+---
+
+add chevron-right and chevron-left icons for small, medium, and large at all sizes

--- a/icon-registry/icons-static/chevron-left-large_x24.svg
+++ b/icon-registry/icons-static/chevron-left-large_x24.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M16.5 21L7.5 12L16.5 3" stroke="currentColor" class="icon-dark" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/icon-registry/icons-static/chevron-left-large_x8.svg
+++ b/icon-registry/icons-static/chevron-left-large_x8.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M5.5 1L2.5 4L5.5 7" stroke="currentColor" class="icon-dark" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/icon-registry/icons-static/chevron-left-medium_x16.svg
+++ b/icon-registry/icons-static/chevron-left-medium_x16.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M10 4L6 8L10 12" stroke="currentColor" class="icon-dark" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/icon-registry/icons-static/chevron-left-medium_x24.svg
+++ b/icon-registry/icons-static/chevron-left-medium_x24.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M15 18L9 12L15 6" stroke="currentColor" class="icon-dark" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/icon-registry/icons-static/chevron-left-small_x24.svg
+++ b/icon-registry/icons-static/chevron-left-small_x24.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M13.5 15L10.5 12L13.5 9" stroke="currentColor" class="icon-dark" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/icon-registry/icons-static/chevron-right-large_x24.svg
+++ b/icon-registry/icons-static/chevron-right-large_x24.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M7.5 21L16.5 12L7.5 3" stroke="currentColor" class="icon-dark" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/icon-registry/icons-static/chevron-right-large_x8.svg
+++ b/icon-registry/icons-static/chevron-right-large_x8.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M2.5 1L5.5 4L2.5 7" stroke="currentColor" class="icon-dark" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/icon-registry/icons-static/chevron-right-medium_x16.svg
+++ b/icon-registry/icons-static/chevron-right-medium_x16.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M6 12L10 8L6 4" stroke="currentColor" class="icon-dark" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/icon-registry/icons-static/chevron-right-medium_x24.svg
+++ b/icon-registry/icons-static/chevron-right-medium_x24.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M9 18L15 12L9 6" stroke="currentColor" class="icon-dark" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/icon-registry/icons-static/chevron-right-small_x24.svg
+++ b/icon-registry/icons-static/chevron-right-small_x24.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M10.5 15L13.5 12L10.5 9" stroke="currentColor" class="icon-dark" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Design system for the marketing site, app and cloud",
   "main": "index.js",
   "repository": "https://github.com/cypress-io/design-system.git",
-  "author": "Bart Ledoux <ledouxb@gmail.com>",
   "license": "MIT",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Originally motivated by needing the right-chevron for [this comp](https://www.figma.com/design/XYBgOykHfLCi1yT4Va7GLO/Test-generation?node-id=3150-137694&t=86v1kwsYgEjakhG3-1) for Studio.

I went ahead and added all sizes and types for all of the chevron left and right icons. So all icons here are in the design-system: https://www.figma.com/design/1WJ3GVQyMV5e7xVxPg3yID/Design-System?m=auto&node-id=6814-10841&t=GrG6iztKgxoEMunp-1

![Screenshot 2025-04-25 at 3 31 36 PM](https://github.com/user-attachments/assets/16514fa1-7705-4675-bee2-8ffd2e9b6831)
