### PR TITLE
Mabel/add button disabled dark mode

### DIFF
--- a/.changeset/clean-carrots-trade.md
+++ b/.changeset/clean-carrots-trade.md
@@ -1,0 +1,7 @@
+---
+'@cypress-design/constants-button': minor
+'@cypress-design/react-button': minor
+'@cypress-design/vue-button': minor
+---
+
+Add disabled-dark-mode variant

--- a/components/Button/constants/src/index.ts
+++ b/components/Button/constants/src/index.ts
@@ -10,7 +10,7 @@ export const CssVariantClassesTable = {
     'text-indigo-500 bg-white border-gray-100 hover:border-gray-200 disabled:hocus:shadow-none hocus:shadow-gray-50 disabled:text-gray-500 focus:ring-gray-200',
   disabled: 'text-gray-500 bg-gray-100 border-gray-100 hover:shadow-none',
   'disabled-dark-mode':
-    'hocus:shadow-none bg-gray-1000 text-gray-800 border-none mix-blend-screen:text-gray-800',
+    'text-gray-800 bg-gray-1000 border-none hocus:shadow-none mix-blend-screen',
   // outline variants
   'outline-indigo':
     'border-indigo-500 text-indigo-500 disabled:hocus:shadow-none hocus:shadow-indigo-300/[.35] disabled:text-gray-500 disabled:border-gray-100 focus:ring-indigo-600',

--- a/components/Button/constants/src/index.ts
+++ b/components/Button/constants/src/index.ts
@@ -9,6 +9,8 @@ export const CssVariantClassesTable = {
   white:
     'text-indigo-500 bg-white border-gray-100 hover:border-gray-200 disabled:hocus:shadow-none hocus:shadow-gray-50 disabled:text-gray-500 focus:ring-gray-200',
   disabled: 'text-gray-500 bg-gray-100 border-gray-100 hover:shadow-none',
+  'disabled-dark-mode':
+    'hocus:shadow-none bg-gray-1000 text-gray-800 border-none mix-blend-screen:text-gray-800',
   // outline variants
   'outline-indigo':
     'border-indigo-500 text-indigo-500 disabled:hocus:shadow-none hocus:shadow-indigo-300/[.35] disabled:text-gray-500 disabled:border-gray-100 focus:ring-indigo-600',

--- a/components/Button/react/Button.rootstory.tsx
+++ b/components/Button/react/Button.rootstory.tsx
@@ -23,7 +23,8 @@ export default ({
                   variant === 'outline-red-dark-mode' ||
                   variant === 'outline-jade-dark-mode' ||
                   variant === 'outline-indigo-dark-mode' ||
-                  variant === 'red-dark-mode',
+                  variant === 'red-dark-mode' ||
+                  variant === 'disabled-dark-mode',
               },
             )}
           >

--- a/components/Button/react/Button.rootstory.tsx
+++ b/components/Button/react/Button.rootstory.tsx
@@ -40,13 +40,15 @@ export default ({
                           variant === 'outline-red-dark-mode' ||
                           variant === 'outline-jade-dark-mode' ||
                           variant === 'outline-indigo-dark-mode' ||
-                          variant === 'red-dark-mode',
+                          variant === 'red-dark-mode' ||
+                          variant === 'disabled-dark-mode',
                         'text-gray-700': ![
                           'outline-dark',
                           'outline-red-dark-mode',
                           'outline-jade-dark-mode',
                           'outline-indigo-dark-mode',
                           'red-dark-mode',
+                          'disabled-dark-mode',
                         ].includes(variant),
                       })}
                     >

--- a/components/Button/react/Button.tsx
+++ b/components/Button/react/Button.tsx
@@ -43,7 +43,10 @@ export const Button: React.FC<ReactButtonProps> = ({
   const finalVariant = useDisabledVariant ? 'disabled' : variant
 
   const finalDisabled =
-    disabled || variant === 'disabled' || variant === 'outline-disabled'
+    disabled ||
+    variant === 'disabled' ||
+    variant === 'outline-disabled' ||
+    variant === 'disabled-dark-mode'
 
   const Comp = href ? 'a' : 'button'
 

--- a/components/Button/react/ReadMe.md
+++ b/components/Button/react/ReadMe.md
@@ -73,7 +73,8 @@ export default () => {
               variant === 'outline-red-dark-mode' ||
               variant === 'outline-jade-dark-mode' ||
               variant === 'outline-indigo-dark-mode' ||
-              variant === 'red-dark-mode'
+              variant === 'red-dark-mode' ||
+              variant === 'disabled-dark-mode'
                 ? '#1a202c'
                 : 'white',
             color:
@@ -81,7 +82,8 @@ export default () => {
               variant === 'outline-red-dark-mode' ||
               variant === 'outline-jade-dark-mode' ||
               variant === 'outline-indigo-dark-mode' ||
-              variant === 'red-dark-mode'
+              variant === 'red-dark-mode' ||
+              variant === 'disabled-dark-mode'
                 ? 'white'
                 : 'black',
           }}

--- a/components/Button/vue/Button.rootstory.tsx
+++ b/components/Button/vue/Button.rootstory.tsx
@@ -20,7 +20,8 @@ export default ({
                   variant === 'outline-red-dark-mode' ||
                   variant === 'outline-jade-dark-mode' ||
                   variant === 'outline-indigo-dark-mode' ||
-                  variant === 'red-dark-mode',
+                  variant === 'red-dark-mode' ||
+                  variant === 'disabled-dark-mode',
               },
             )}
           >
@@ -37,13 +38,15 @@ export default ({
                           variant === 'outline-red-dark-mode' ||
                           variant === 'outline-jade-dark-mode' ||
                           variant === 'outline-indigo-dark-mode' ||
-                          variant === 'red-dark-mode',
+                          variant === 'red-dark-mode' ||
+                          variant === 'disabled-dark-mode',
                         'text-gray-700': ![
                           'outline-dark',
                           'outline-red-dark-mode',
                           'outline-jade-dark-mode',
                           'outline-indigo-dark-mode',
                           'red-dark-mode',
+                          'disabled-dark-mode',
                         ].includes(variant),
                       })}
                     >

--- a/components/Button/vue/Button.vue
+++ b/components/Button/vue/Button.vue
@@ -65,7 +65,8 @@ export default defineComponent({
       () =>
         props.disabled ||
         props.variant === 'disabled' ||
-        props.variant === 'outline-disabled',
+        props.variant === 'outline-disabled' ||
+        props.variant === 'disabled-dark-mode',
     )
 
     const variantClasses = computed(

--- a/components/Button/vue/ReadMe.md
+++ b/components/Button/vue/ReadMe.md
@@ -76,13 +76,15 @@ import {
           variant === 'outline-red-dark-mode' ||
           variant === 'outline-jade-dark-mode' ||
           variant === 'outline-indigo-dark-mode' ||
-          variant === 'red-dark-mode',
+          variant === 'red-dark-mode' ||
+          variant === 'disabled-dark-mode',
         'bg-white text-gray-900': ![
           'outline-dark',
           'outline-red-dark-mode',
           'outline-jade-dark-mode',
           'outline-indigo-dark-mode',
           'red-dark-mode',
+          'disabled-dark-mode',
         ].includes(variant),
       }"
     >


### PR DESCRIPTION
Add a `disabled-dark-mode` variant mainly for the `-dark` variants that only have the disabled styles for the light theme and are missing the ones for the dark theme

![image](https://github.com/user-attachments/assets/4bdf6ec9-e880-4a7e-8907-80c206664d96)

