### PR TITLE
fix accessibility violations on react button tests

### DIFF
--- a/components/Button/assertions.ts
+++ b/components/Button/assertions.ts
@@ -26,7 +26,6 @@ export default function assertions(
       'text-decoration-line',
       'underline',
     )
-    cy
   })
 
   it('renders variants', () => {

--- a/components/Button/react/Button.rootstory.tsx
+++ b/components/Button/react/Button.rootstory.tsx
@@ -9,7 +9,7 @@ export default ({
   href,
   onClick,
 }: { disabled?: boolean; href?: string; onClick?: () => void } = {}) => (
-  <div className="flex flex-row flex-wrap justify-center gap-2">
+  <div className="flex flex-row flex-wrap justify-center gap-2 bg-white">
     {(Object.keys(CssVariantClassesTable) as ButtonVariants[]).map(
       (variant) => {
         return (
@@ -37,26 +37,19 @@ export default ({
                 return (
                   <div key={size} className="flex items-center justify-center">
                     <span
-                      className={clsx('text-sm mr-4', {
-                        'text-gray-300':
-                          variant === 'outline-dark' ||
+                      className={clsx(
+                        'text-sm mr-4',
+                        variant === 'outline-dark' ||
                           variant === 'outline-red-dark-mode' ||
                           variant === 'outline-jade-dark-mode' ||
                           variant === 'outline-indigo-dark-mode' ||
                           variant === 'outline-purple-dark-mode' ||
                           variant === 'red-dark-mode' ||
                           variant === 'indigo-dark-mode' ||
-                          variant === 'disabled-dark-mode',
-                        'text-gray-700': ![
-                          'outline-dark',
-                          'outline-red-dark-mode',
-                          'outline-jade-dark-mode',
-                          'outline-indigo-dark-mode',
-                          'red-dark-mode',
-                          'indigo-dark-mode',
-                          'disabled-dark-mode',
-                        ].includes(variant),
-                      })}
+                          variant === 'disabled-dark-mode'
+                          ? 'text-gray-300'
+                          : 'text-gray-900',
+                      )}
                     >
                       {size}
                     </span>


### PR DESCRIPTION
This [test](https://cloud.cypress.io/projects/89d3nq/runs/3195/test-results?utm_source=github&statuses=%5B%7B%22value%22%3A%22FAILED%22%2C%22label%22%3A%22FAILED%22%7D%5D) is failing because of an accessibility violation in the html we set up to test the Buttons in React. I updated the text for certain variants to be `text-gray-900` instead of `text-gray-700`

Note: this change only affects the actual test set up for the `ButtonReact.cy.tsx` test