### PR TITLE
Split tailwind exports into separate entry point

### DIFF
--- a/.changeset/split-tailwind-entrypoint.md
+++ b/.changeset/split-tailwind-entrypoint.md
@@ -1,5 +1,5 @@
 ---
-"@cypress-design/css": breaking
+"@cypress-design/css": major
 ---
 
 Add `@cypress-design/css/tailwind` entry point for TailwindConfig and TailwindIconExtractor exports. These Node.js-only exports have been moved out of the main entry point so that browser bundlers (like Vite) no longer need to stub `process.env` and `tty` when consuming `@cypress-design/css`.

--- a/.changeset/split-tailwind-entrypoint.md
+++ b/.changeset/split-tailwind-entrypoint.md
@@ -1,0 +1,12 @@
+---
+"@cypress-design/css": minor
+---
+
+Add `@cypress-design/css/tailwind` entry point for TailwindConfig and TailwindIconExtractor exports. These Node.js-only exports have been moved out of the main entry point so that browser bundlers (like Vite) no longer need to stub `process.env` and `tty` when consuming `@cypress-design/css`.
+
+Consumers using `TailwindConfig` or `TailwindIconExtractor` should update their imports:
+
+```diff
+- const { TailwindConfig } = require('@cypress-design/css')
++ const { TailwindConfig } = require('@cypress-design/css/tailwind')
+```

--- a/.changeset/split-tailwind-entrypoint.md
+++ b/.changeset/split-tailwind-entrypoint.md
@@ -1,5 +1,5 @@
 ---
-"@cypress-design/css": minor
+"@cypress-design/css": breaking
 ---
 
 Add `@cypress-design/css/tailwind` entry point for TailwindConfig and TailwindIconExtractor exports. These Node.js-only exports have been moved out of the main entry point so that browser bundlers (like Vite) no longer need to stub `process.env` and `tty` when consuming `@cypress-design/css`.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -20,7 +20,7 @@ Then configure your tailwind.config.cjs using the following template
 
 ```js
 // tailwind.config.cjs
-const { TailwindConfig } = require('@cypress-design/css')
+const { TailwindConfig } = require('@cypress-design/css/tailwind')
 
 module.exports = TailwindConfig([
   './index.html',

--- a/css/ReadMe.md
+++ b/css/ReadMe.md
@@ -62,7 +62,7 @@ This config is less verbose but only allows you to customize the files scanned.
 
 ```js
 // tailwind.config.cjs
-const { TailwindConfig } = require('@cypress-design/css')
+const { TailwindConfig } = require('@cypress-design/css/tailwind')
 
 module.exports = TailwindConfig([
   './index.html',
@@ -76,7 +76,7 @@ If you plan on configuring
 
 ```js
 // tailwind.config.cjs
-const cypressCSS = require('@cypress-design/css')
+const cypressCSS = require('@cypress-design/css/tailwind')
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
@@ -96,7 +96,7 @@ module.exports = {
 ### Webpack
 
 ```js
-const { CyCSSWebpackPlugin } = require('@cypress-design/css')
+const { CyCSSWebpackPlugin } = require('@cypress-design/css/tailwind')
 
 module.exports = {
   plugins: [

--- a/css/package.json
+++ b/css/package.json
@@ -57,5 +57,12 @@
     "ts-node": "^10.9.2",
     "typescript": "5.4.5"
   },
+  "typesVersions": {
+    "*": {
+      "tailwind": [
+        "./dist/tailwind.d.ts"
+      ]
+    }
+  },
   "license": "MIT"
 }

--- a/css/package.json
+++ b/css/package.json
@@ -22,6 +22,11 @@
       "require": "./dist/colors.cjs.js",
       "types": "./dist/colors.d.ts"
     },
+    "./tailwind": {
+      "import": "./dist/tailwind.es.mjs",
+      "require": "./dist/tailwind.cjs.js",
+      "types": "./dist/tailwind.d.ts"
+    },
     "./dist/color-constants": {
       "import": "./dist/color-constants.es.mjs",
       "require": "./dist/color-constants.cjs.js",

--- a/css/rollup.config.mjs
+++ b/css/rollup.config.mjs
@@ -8,7 +8,7 @@ const external = Object.keys(pkg.dependencies)
 
 const exports = Object.keys(pkg.exports)
   .filter((r) => r !== '.' && !r.endsWith('.json'))
-  .map((r) => r.replace(/^\.\/dist\//, ''))
+  .map((r) => r.replace(/^\.\/dist\//, '').replace(/^\.\//, ''))
 
 const config = ({ input, outputFile }) => {
   return {

--- a/css/src/index.ts
+++ b/css/src/index.ts
@@ -6,5 +6,3 @@ export {
   ADDITIONAL_COLORS,
 } from './icon-extractor-tools'
 
-export { default as TailwindConfig } from './tailwind.config'
-export { IconExtractor as TailwindIconExtractor } from './tw-icon-extractor'

--- a/css/src/tailwind.ts
+++ b/css/src/tailwind.ts
@@ -1,0 +1,2 @@
+export { default as TailwindConfig } from './tailwind.config'
+export { IconExtractor as TailwindIconExtractor } from './tw-icon-extractor'

--- a/docs/2-Install.md
+++ b/docs/2-Install.md
@@ -42,7 +42,7 @@ This config is less verbose but only allows you to customize the files scanned.
 
 ```js
 // tailwind.config.cjs
-const { TailwindConfig } = require('@cypress-design/css')
+const { TailwindConfig } = require('@cypress-design/css/tailwind')
 
 module.exports = TailwindConfig([
   './index.html',
@@ -56,7 +56,7 @@ If you plan on configuring
 
 ```js
 // tailwind.config.cjs
-const cypressCSS = require('@cypress-design/css')
+const cypressCSS = require('@cypress-design/css/tailwind')
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
@@ -78,7 +78,7 @@ module.exports = {
 ### Webpack
 
 ```js
-const { CyCSSWebpackPlugin } = require('@cypress-design/css')
+const { CyCSSWebpackPlugin } = require('@cypress-design/css/tailwind')
 
 module.exports = {
   plugins: [

--- a/packages/rollup-plugin-tailwind-keep/src/tailwind-keep-rollup-plugin.ts
+++ b/packages/rollup-plugin-tailwind-keep/src/tailwind-keep-rollup-plugin.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from 'vite'
 import { Context } from 'tailwindcss/lib/Context'
-import { TailwindConfig, TailwindIconExtractor } from '@cypress-design/css'
+import { TailwindConfig, TailwindIconExtractor } from '@cypress-design/css/tailwind'
 
 export default function TailwindKeepRollupPlugin(): Plugin {
   const classSet = new Set<string>()

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -2,8 +2,8 @@
 import {
   TailwindConfig,
   TailwindIconExtractor,
-  colors,
-} from '@cypress-design/css'
+} from '@cypress-design/css/tailwind'
+import { colors } from '@cypress-design/css'
 import _ from 'lodash'
 import * as path from 'path'
 import { dirname } from 'path'

--- a/test/react-app/tailwind.config.cjs
+++ b/test/react-app/tailwind.config.cjs
@@ -1,4 +1,4 @@
-const cypressCSS = require('@cypress-design/css')
+const cypressCSS = require('@cypress-design/css/tailwind')
 const filePaths = [
   './index.html',
   './src/**/*.{js,ts,jsx,tsx}',

--- a/test/vue-app/tailwind.config.cjs
+++ b/test/vue-app/tailwind.config.cjs
@@ -1,4 +1,4 @@
-const cypressCSS = require('@cypress-design/css')
+const cypressCSS = require('@cypress-design/css/tailwind')
 const filePaths = [
   './index.html',
   './src/**/*.{vue,js,ts,jsx,tsx}',


### PR DESCRIPTION
## Summary
- Moves `TailwindConfig` and `TailwindIconExtractor` from `@cypress-design/css` to a new `@cypress-design/css/tailwind` entry point
- The main `@cypress-design/css` entry now only exports browser-safe code (colors, icon extractor tools, CSS)
- Prevents Vite and other browser bundlers from pulling in `tailwindcss` → `picocolors` → `tty.isatty()` when only consuming colors/constants

## Motivation
Consumers using Vite were forced to stub `process.env` and `tty` because the main entry point re-exported tailwind config utilities that transitively depend on Node.js APIs via `picocolors`.

## Migration
```diff
- const { TailwindConfig } = require('@cypress-design/css')
+ const { TailwindConfig } = require('@cypress-design/css/tailwind')
```

## Test plan
- [ ] Verify `@cypress-design/css` builds successfully with the new `tailwind` entry point
- [ ] Verify consuming projects can import `@cypress-design/css` in Vite without Node.js stubs
- [ ] Verify tailwind configs still work when importing from `@cypress-design/css/tailwind`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major breaking change for consumers importing `TailwindConfig`/`TailwindIconExtractor`, plus packaging/export-map adjustments that could impact builds if misconfigured.
> 
> **Overview**
> Splits Node/Tailwind-specific utilities out of the main `@cypress-design/css` entrypoint by introducing a new `@cypress-design/css/tailwind` export for `TailwindConfig` and `TailwindIconExtractor`, leaving the root entrypoint browser-safe.
> 
> Updates the `@cypress-design/css` export map/types (`exports`, `typesVersions`) and Rollup config to build the new entrypoint, and migrates internal docs/configs and the `rollup-plugin-tailwind-keep` package to import from `@cypress-design/css/tailwind` instead of `@cypress-design/css`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11136d662942ad122f090f4dcca35fa2f2c7e30c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->