### PR TITLE
Add security-shield-failed (12px, 16px) and security-shield-check (12px)

### DIFF
--- a/.changeset/add-security-shield-failed-icon.md
+++ b/.changeset/add-security-shield-failed-icon.md
@@ -1,0 +1,7 @@
+---
+"@cypress-design/icon-registry": minor
+"@cypress-design/react-icon": minor
+"@cypress-design/vue-icon": minor
+---
+
+Add `security-shield-failed` icon (16px).

--- a/.changeset/add-security-shield-icons.md
+++ b/.changeset/add-security-shield-icons.md
@@ -4,4 +4,4 @@
 "@cypress-design/vue-icon": minor
 ---
 
-Add `security-shield-failed` icon (16px).
+Add `security-shield-failed` (12px and 16px) and `security-shield-check` (12px).

--- a/icon-registry/icons-static/security-shield-check_x12.svg
+++ b/icon-registry/icons-static/security-shield-check_x12.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M6 1C6 1 4 2 1.5 2.5V8.14286C2.25 10.2857 6 11 6 11V1Z" class="icon-light" />
+  <path stroke="currentColor" d="M4.5 6L5.75 7.5L7.5 4.5M10.5 2.5C8 2 6 1 6 1C6 1 4 2 1.5 2.5V8.14286C2.25 10.2857 6 11 6 11C6 11 9.75 10.2857 10.5 8.14286V2.5Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon-dark" />
+</svg>

--- a/icon-registry/icons-static/security-shield-check_x12.svg
+++ b/icon-registry/icons-static/security-shield-check_x12.svg
@@ -1,4 +1,4 @@
 <svg viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M6 1C6 1 4 2 1.5 2.5V8.14286C2.25 10.2857 6 11 6 11V1Z" class="icon-light" />
+  <path fill="#D0D2E0" fill-rule="evenodd" clip-rule="evenodd" d="M6 1C6 1 4 2 1.5 2.5V8.14286C2.25 10.2857 6 11 6 11V1Z" class="icon-light" />
   <path stroke="currentColor" d="M4.5 6L5.75 7.5L7.5 4.5M10.5 2.5C8 2 6 1 6 1C6 1 4 2 1.5 2.5V8.14286C2.25 10.2857 6 11 6 11C6 11 9.75 10.2857 10.5 8.14286V2.5Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon-dark" />
 </svg>

--- a/icon-registry/icons-static/security-shield-check_x12.svg
+++ b/icon-registry/icons-static/security-shield-check_x12.svg
@@ -1,4 +1,4 @@
 <svg viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path fill="#D0D2E0" fill-rule="evenodd" clip-rule="evenodd" d="M6 1C6 1 4 2 1.5 2.5V8.14286C2.25 10.2857 6 11 6 11V1Z" class="icon-light" />
+  <path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M6 1C6 1 4 2 1.5 2.5V8.14286C2.25 10.2857 6 11 6 11V1Z" class="icon-light" />
   <path stroke="currentColor" d="M4.5 6L5.75 7.5L7.5 4.5M10.5 2.5C8 2 6 1 6 1C6 1 4 2 1.5 2.5V8.14286C2.25 10.2857 6 11 6 11C6 11 9.75 10.2857 10.5 8.14286V2.5Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon-dark" />
 </svg>

--- a/icon-registry/icons-static/security-shield-failed_x12.svg
+++ b/icon-registry/icons-static/security-shield-failed_x12.svg
@@ -1,4 +1,4 @@
 <svg viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path fill="#D0D2E0" fill-rule="evenodd" clip-rule="evenodd" d="M6 1C6 1 4 2 1.5 2.5V8.14286C2.25 10.2857 6 11 6 11V1Z" class="icon-light" />
+  <path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M6 1C6 1 4 2 1.5 2.5V8.14286C2.25 10.2857 6 11 6 11V1Z" class="icon-light" />
   <path stroke="currentColor" d="M4.5 7.49999L6 5.99999M7.5 4.5L6 5.99999M6 5.99999L4.5 4.49999M6 5.99999L7.5 7.49999M10.5 2.5C8 2 6 1 6 1C6 1 4 2 1.5 2.5V8.14286C2.25 10.2857 6 11 6 11C6 11 9.75 10.2857 10.5 8.14286V2.5Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon-dark" />
 </svg>

--- a/icon-registry/icons-static/security-shield-failed_x12.svg
+++ b/icon-registry/icons-static/security-shield-failed_x12.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M6 1C6 1 4 2 1.5 2.5V8.14286C2.25 10.2857 6 11 6 11V1Z" class="icon-light" />
+  <path stroke="currentColor" d="M4.5 7.49999L6 5.99999M7.5 4.5L6 5.99999M6 5.99999L4.5 4.49999M6 5.99999L7.5 7.49999M10.5 2.5C8 2 6 1 6 1C6 1 4 2 1.5 2.5V8.14286C2.25 10.2857 6 11 6 11C6 11 9.75 10.2857 10.5 8.14286V2.5Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon-dark" />
+</svg>

--- a/icon-registry/icons-static/security-shield-failed_x12.svg
+++ b/icon-registry/icons-static/security-shield-failed_x12.svg
@@ -1,4 +1,4 @@
 <svg viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M6 1C6 1 4 2 1.5 2.5V8.14286C2.25 10.2857 6 11 6 11V1Z" class="icon-light" />
+  <path fill="#D0D2E0" fill-rule="evenodd" clip-rule="evenodd" d="M6 1C6 1 4 2 1.5 2.5V8.14286C2.25 10.2857 6 11 6 11V1Z" class="icon-light" />
   <path stroke="currentColor" d="M4.5 7.49999L6 5.99999M7.5 4.5L6 5.99999M6 5.99999L4.5 4.49999M6 5.99999L7.5 7.49999M10.5 2.5C8 2 6 1 6 1C6 1 4 2 1.5 2.5V8.14286C2.25 10.2857 6 11 6 11C6 11 9.75 10.2857 10.5 8.14286V2.5Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon-dark" />
 </svg>

--- a/icon-registry/icons-static/security-shield-failed_x16.svg
+++ b/icon-registry/icons-static/security-shield-failed_x16.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M8 1.33334C8 1.33334 5.33333 2.66668 2 3.33334V10.8572C3 13.7143 8 14.6667 8 14.6667V1.33334Z" class="icon-light" />
+  <path stroke="currentColor" d="M6 10L8 8M10 6.00001L8 8M8 8L6 6M8 8L10 10M14 3.33334C10.6667 2.66668 8 1.33334 8 1.33334C8 1.33334 5.33333 2.66668 2 3.33334V10.8572C3 13.7143 8 14.6667 8 14.6667C8 14.6667 13 13.7143 14 10.8572V3.33334Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon-dark" />
+</svg>

--- a/icon-registry/icons-static/security-shield-failed_x16.svg
+++ b/icon-registry/icons-static/security-shield-failed_x16.svg
@@ -1,4 +1,4 @@
 <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path fill="#D0D2E0" fill-rule="evenodd" clip-rule="evenodd" d="M8 1.33334C8 1.33334 5.33333 2.66668 2 3.33334V10.8572C3 13.7143 8 14.6667 8 14.6667V1.33334Z" class="icon-light" />
+  <path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M8 1.33334C8 1.33334 5.33333 2.66668 2 3.33334V10.8572C3 13.7143 8 14.6667 8 14.6667V1.33334Z" class="icon-light" />
   <path stroke="currentColor" d="M6 10L8 8M10 6.00001L8 8M8 8L6 6M8 8L10 10M14 3.33334C10.6667 2.66668 8 1.33334 8 1.33334C8 1.33334 5.33333 2.66668 2 3.33334V10.8572C3 13.7143 8 14.6667 8 14.6667C8 14.6667 13 13.7143 14 10.8572V3.33334Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon-dark" />
 </svg>

--- a/icon-registry/icons-static/security-shield-failed_x16.svg
+++ b/icon-registry/icons-static/security-shield-failed_x16.svg
@@ -1,4 +1,4 @@
 <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M8 1.33334C8 1.33334 5.33333 2.66668 2 3.33334V10.8572C3 13.7143 8 14.6667 8 14.6667V1.33334Z" class="icon-light" />
+  <path fill="#D0D2E0" fill-rule="evenodd" clip-rule="evenodd" d="M8 1.33334C8 1.33334 5.33333 2.66668 2 3.33334V10.8572C3 13.7143 8 14.6667 8 14.6667V1.33334Z" class="icon-light" />
   <path stroke="currentColor" d="M6 10L8 8M10 6.00001L8 8M8 8L6 6M8 8L10 10M14 3.33334C10.6667 2.66668 8 1.33334 8 1.33334C8 1.33334 5.33333 2.66668 2 3.33334V10.8572C3 13.7143 8 14.6667 8 14.6667C8 14.6667 13 13.7143 14 10.8572V3.33334Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon-dark" />
 </svg>


### PR DESCRIPTION
## Summary

This branch adds new static icons for security shield states and sizes, aligned with existing `security-shield-*` artwork (light shield face `#D0D2E0` with `icon-light`, outline and mark `stroke="currentColor"` with `icon-dark`).

## New assets

| File | Description |
|------|-------------|
| `icon-registry/icons-static/security-shield-failed_x16.svg` | Failed shield (X), 16px |
| `icon-registry/icons-static/security-shield-failed_x12.svg` | Failed shield (X), 12px |
| `icon-registry/icons-static/security-shield-check_x12.svg` | Check shield, 12px (16px and 24px already existed) |

## Changeset

- `.changeset/add-security-shield-icons.md` — single minor bump for `@cypress-design/icon-registry`, `@cypress-design/react-icon`, and `@cypress-design/vue-icon`.

## Figma sources

- [security-shield-failed — 16px frame](https://www.figma.com/design/1WJ3GVQyMV5e7xVxPg3yID/Design-System?node-id=22082-582)
- [security-shield-failed — 12px frame](https://www.figma.com/design/1WJ3GVQyMV5e7xVxPg3yID/Design-System?node-id=22082-591)
- [security-shield-check — 12px frame](https://www.figma.com/design/1WJ3GVQyMV5e7xVxPg3yID/Design-System?node-id=22082-595)

## Implementation notes

- Shield fill uses **`#D0D2E0`** (not `currentColor`) so the light face does not inherit unintended fill when consumers omit fill color props.
- `icon-registry/src/icons.ts` is generated when building the icon-registry package and is not committed.

## How to verify

```bash
yarn start
```

Open `http://localhost:5173/Icons` and search for `security-shield-failed` and `security-shield-check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new SVG assets and a changeset for package version bumps without changing runtime logic.
> 
> **Overview**
> Adds new static shield-state icons to the registry: `security-shield-failed` (12px and 16px) and `security-shield-check` (12px).
> 
> Includes a changeset to publish minor version bumps for `@cypress-design/icon-registry`, `@cypress-design/react-icon`, and `@cypress-design/vue-icon` so the new icons become available to consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d6ea5f63f4e93b859ec53be2b6b523314dab6ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->