### PR TITLE
docs(Select): stage 1 — instructions + architecture for new Select component

### DIFF
--- a/.agents/index.md
+++ b/.agents/index.md
@@ -43,7 +43,7 @@ Fetch on demand — don't preload all of them:
 `Accordion` `Alert` `Button` `Checkbox` `Icon` `Logo` `Menu` `Modal` `Spinner` `Tabs` `Textbox` `Tooltip`
 `DocMenu` — sidebar navigation used in documentation sites
 `RunResults` — pill of test result counts (passed/failed/skipped/pending) with optional flaky and self-healed leading stats
-`Select` — single-select dropdown with Textbox trigger, optional header (title / tabs / search), optional footer, and pluggable row content types (default / headline / divider / checkbox / user / button / custom)
+`Select` — single-select dropdown with Button trigger (swappable), optional header (title / tabs / search), optional footer, and pluggable row content types (default / headline / divider / checkbox / user / button / custom)
 `StatusIcon` — passed/failed/pending/skipped/running/flaky indicator
 `Tag` — small colored label
 `TestResult` — single test result row with status, title, and actions

--- a/.agents/index.md
+++ b/.agents/index.md
@@ -43,6 +43,7 @@ Fetch on demand — don't preload all of them:
 `Accordion` `Alert` `Button` `Checkbox` `Icon` `Logo` `Menu` `Modal` `Spinner` `Tabs` `Textbox` `Tooltip`
 `DocMenu` — sidebar navigation used in documentation sites
 `RunResults` — pill of test result counts (passed/failed/skipped/pending) with optional flaky and self-healed leading stats
+`Select` — single-select dropdown with Textbox trigger, optional header (title / tabs / search), optional footer, and pluggable row content types (default / headline / divider / checkbox / user / button / custom)
 `StatusIcon` — passed/failed/pending/skipped/running/flaky indicator
 `Tag` — small colored label
 `TestResult` — single test result row with status, title, and actions

--- a/components/Select/architecture.md
+++ b/components/Select/architecture.md
@@ -34,9 +34,9 @@ The package exports three named components per framework: `Select` (default), `S
 
 Select does not reimplement primitives that already exist in cypress-design. Specifically:
 
-- **Default trigger** is a [`Textbox`](../Textbox/architecture.md) styled with the same variant classes (`@cypress-design/constants-textbox`'s `CssVariantClasses`), with `iconRight` set to a chevron icon. Textbox does the heavy lifting for sizing, hover, focus, disabled visuals.
+- **Default trigger** is a [`Button`](../Button/) rendering `{selectedLabel ?? placeholder}` followed by a chevron icon as the last child of the button's default slot. Button has no `iconRight` prop, so the chevron is just a child node. The chevron rotates 180° while `open === true`. Button's variant and size do the heavy lifting for hover, focus-visible, disabled visuals.
 - **Header tabs** are the existing [`Tabs`](../Tabs/) component.
-- **Search input** in the header is a Textbox sized to match the row size.
+- **Search input** in the header is a [`Textbox`](../Textbox/) sized to match the row size.
 - **`type: 'checkbox'` rows** render the existing [`Checkbox`](../Checkbox/) component to the left of the label.
 - **`type: 'button'` rows** render the existing [`Button`](../Button/) component.
 - **`tag`** on default rows renders the existing [`Tag`](../Tag/) component.
@@ -87,6 +87,14 @@ Keying mirrors Textbox: every visual state for a given `(theme, size)` lives in 
 The popover is `position: absolute` inside a wrapper that's `position: relative`. The wrapper is the same DOM node as the trigger, so the popover is naturally anchored to it. `align` is implemented with `left-0` / `right-0` (no JS calculations).
 
 There is no viewport collision detection. If the popover overflows the viewport in the chosen direction, the consumer must change `align` or place the trigger differently. Picking up Floating UI is a future option but adds a runtime dependency.
+
+## Popover sizing
+
+The `width`, `minWidth`, `maxWidth`, `height`, `maxHeight` props are applied as inline `style` properties on the popover panel — not as Tailwind classes. A small helper coerces incoming values to CSS strings (a plain `number` becomes `${n}px`; any other value is passed through unchanged so `'20rem'` or `'min(100vw, 320px)'` work).
+
+Inline style is the right tool here because these dimensions are user-supplied at runtime and there is no closed set of values to enumerate as utility classes.
+
+When `maxHeight` is set and the rows would overflow, the **items area** scrolls — the header and footer stay pinned. This is done with `display: flex; flex-direction: column` on the popover panel and `overflow-y: auto; flex: 1 1 auto; min-height: 0` on the items wrapper. Header and footer get `flex-shrink: 0`.
 
 ## Filtering
 

--- a/components/Select/architecture.md
+++ b/components/Select/architecture.md
@@ -52,9 +52,9 @@ There are three pieces of internal state:
 2. **`selectedValue: string | undefined`** — current selection. Controlled when `value` is provided, uncontrolled otherwise.
 3. **`focusedIndex: number`** — index of the currently focused (keyboard-traversed) row inside the _filtered_ item list. Reset to the index of the selected item whenever the popover opens.
 
-Search input value is also internal state, scoped to OptionList. Header active-tab is controlled by the consumer.
+Search input value (`searchValue`) is also internal state, owned by `Select` (not `SelectOptionList`). The popover receives it as a controlled prop and emits `update:searchValue` / calls `onSearchValueChange` when the input changes. Keeping it on `Select` is what makes keyboard nav and rendering agree on the filtered list — Select computes `displayItems = filterAndCollapseHeadlines(items, searchValue)` once and feeds it to OptionList; both keyboard traversal indices and rendered rows derive from the same array. Header active-tab is controlled by the consumer.
 
-All three pieces of state live in `Select`. `SelectOptionList` receives them as props plus callback setters. `SelectOptionItem` is presentational only — it gets `selected`, `focused`, `disabled` booleans and a click handler.
+All four pieces of state live in `Select`. `SelectOptionList` receives them as props plus callback setters. `SelectOptionItem` is presentational only — it gets `selected`, `focused`, `disabled` booleans and a click handler.
 
 ## Why JS-driven focus (not real DOM focus)
 
@@ -98,7 +98,7 @@ When `maxHeight` is set and the rows would overflow, the **items area** scrolls 
 
 ## Filtering
 
-When `searchable` is true, OptionList maintains a local `searchValue` string. Items are filtered before render:
+When `searchable` is true, `Select` (not OptionList) owns the `searchValue` string and computes a derived `displayItems` array via `filterAndCollapseHeadlines(items, searchValue)`. The filtered list is passed down to OptionList as the `items` prop; OptionList does no filtering of its own. Items are filtered before render:
 
 - The filter is case-insensitive substring match against `item.label`.
 - `headline` and `divider` rows are always rendered (they're structural).

--- a/components/Select/architecture.md
+++ b/components/Select/architecture.md
@@ -1,0 +1,146 @@
+# Select — architecture
+
+How the Select component is built. Read this when extending, fixing, or rebuilding the component. For usage, see [`instructions.md`](./instructions.md).
+
+## File layout
+
+```
+components/Select/
+├── ReadMe.md                       # Public Astro/VitePress docs (live demos)
+├── instructions.md                 # Consumer-facing usage doc
+├── architecture.md                 # This file — implementation notes
+├── assertions.ts                   # Shared Cypress assertions (open/close, selected, etc.)
+├── constants/src/
+│   ├── base-classes.ts             # Wrapper + trigger + popover + size classes
+│   ├── option-item-classes.ts      # CssOptionItemClasses keyed by `${theme}-${state}`
+│   ├── option-list-classes.ts      # Popover panel + header + footer classes per theme
+│   ├── content-type-classes.ts     # Per-content-type row internals (checkbox, user, button, etc.)
+│   └── index.ts                    # Re-exports + SelectProps + SelectItem types + Default* values
+├── react/
+│   ├── Select.tsx                  # Main; orchestrates trigger + popover
+│   ├── SelectOptionList.tsx        # Panel; header + items + footer; filter logic
+│   ├── SelectOptionItem.tsx        # Single row; dispatches on `type`
+│   └── SelectReact.cy.tsx
+└── vue/
+    ├── Select.vue                  # Mirrors React orchestration
+    ├── _SelectOptionList.vue       # Private sub-component
+    ├── _SelectOptionItem.vue       # Private sub-component
+    └── SelectVue.cy.tsx
+```
+
+The package exports three named components per framework: `Select` (default), `SelectOptionList`, and `SelectOptionItem`. `Select` is the entry point for all common use cases; the sub-components are exported so a consumer can reuse the popover panel inside their own popover plumbing (e.g. a Floating UI tooltip).
+
+## Composition over invention
+
+Select does not reimplement primitives that already exist in cypress-design. Specifically:
+
+- **Default trigger** is a [`Textbox`](../Textbox/architecture.md) styled with the same variant classes (`@cypress-design/constants-textbox`'s `CssVariantClasses`), with `iconRight` set to a chevron icon. Textbox does the heavy lifting for sizing, hover, focus, disabled visuals.
+- **Header tabs** are the existing [`Tabs`](../Tabs/) component.
+- **Search input** in the header is a Textbox sized to match the row size.
+- **`type: 'checkbox'` rows** render the existing [`Checkbox`](../Checkbox/) component to the left of the label.
+- **`type: 'button'` rows** render the existing [`Button`](../Button/) component.
+- **`tag`** on default rows renders the existing [`Tag`](../Tag/) component.
+- **All icons** (chevron, search, item `iconLeft`, the avatar of `type: 'user'` rows) go through [`@cypress-design/react-icon` / `vue-icon`](../Icon/). Select does not ship a custom Avatar component.
+
+If you find yourself styling a checkbox or button by hand inside Select, stop — use the shared primitive instead.
+
+## State ownership
+
+There are three pieces of internal state:
+
+1. **`open: boolean`** — popover visibility. Controlled when `open` prop is provided, uncontrolled otherwise (`useState(defaultOpen ?? false)`).
+2. **`selectedValue: string | undefined`** — current selection. Controlled when `value` is provided, uncontrolled otherwise.
+3. **`focusedIndex: number`** — index of the currently focused (keyboard-traversed) row inside the _filtered_ item list. Reset to the index of the selected item whenever the popover opens.
+
+Search input value is also internal state, scoped to OptionList. Header active-tab is controlled by the consumer.
+
+All three pieces of state live in `Select`. `SelectOptionList` receives them as props plus callback setters. `SelectOptionItem` is presentational only — it gets `selected`, `focused`, `disabled` booleans and a click handler.
+
+## Why JS-driven focus (not real DOM focus)
+
+Rows do not receive real DOM focus. Instead:
+
+- The trigger (or the search Textbox, if the popover has a search input) keeps real DOM focus.
+- The currently keyboard-focused row is marked with `data-focused="true"` and referenced from the focus owner via `aria-activedescendant`.
+- Hover and focus visuals share a single Tailwind line in the constants (`hover:... data-[focused=true]:...`) so the visual treatment is identical regardless of input modality.
+
+This avoids the awkward "is the search input focused or is an option focused?" problem and matches the [ARIA combobox-with-listbox-popup pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/).
+
+## Constants keying
+
+| Constant                   | Keys                | Purpose                                                                                                                                       |
+| -------------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CssStaticClasses`         | —                   | Static classes applied to every Select wrapper                                                                                                |
+| `CssPopoverClasses`        | `theme`             | Popover panel container (background, border, shadow, rounding)                                                                                |
+| `CssPopoverSizeClasses`    | `size`              | Popover padding / min-width / row spacing                                                                                                     |
+| `CssOptionItemClasses`     | `${theme}-default`  | Row classes. Includes hover, active, focus-visible, disabled, selected pseudo / data-attr modifiers in one string — same approach as Textbox. |
+| `CssOptionItemSizeClasses` | `size`              | Row height + horizontal padding                                                                                                               |
+| `CssOptionItemTypeClasses` | `type`              | Per-content-type structural classes (gap, alignment, two-line text)                                                                           |
+| `CssHeaderClasses`         | `theme`             | Header container background + border                                                                                                          |
+| `CssFooterClasses`         | `theme`             | Footer container background + border                                                                                                          |
+| `CssAlignmentClasses`      | `'left' \| 'right'` | Popover horizontal offset relative to the trigger                                                                                             |
+
+Keying mirrors Textbox: every visual state for a given `(theme, size)` lives in a single class string with `:hover` / `data-[focused=true]:` / `data-[selected=true]:` / `aria-[disabled=true]:` modifiers. Adding a state means editing the strings, not adding new keys.
+
+## Popover positioning
+
+The popover is `position: absolute` inside a wrapper that's `position: relative`. The wrapper is the same DOM node as the trigger, so the popover is naturally anchored to it. `align` is implemented with `left-0` / `right-0` (no JS calculations).
+
+There is no viewport collision detection. If the popover overflows the viewport in the chosen direction, the consumer must change `align` or place the trigger differently. Picking up Floating UI is a future option but adds a runtime dependency.
+
+## Filtering
+
+When `searchable` is true, OptionList maintains a local `searchValue` string. Items are filtered before render:
+
+- The filter is case-insensitive substring match against `item.label`.
+- `headline` and `divider` rows are always rendered (they're structural).
+- If a `headline` group has no matching rows after filtering, the headline is hidden too — drop empty groups so the popover doesn't show stray section headers.
+- `button` rows are always rendered (they're CTAs, not filterable options).
+
+Custom filtering (fuzzy match, multi-field, async) is not built in. The consumer can pass an already-filtered `items` array and skip `searchable`.
+
+## Click-outside and ESC
+
+A capture-phase `mousedown` listener on `document` closes the popover when the event's target is outside both the wrapper and the popover. A `keydown` listener on the wrapper handles `Escape` and the arrow keys.
+
+In Vue, both listeners are wired in `onMounted` / `onBeforeUnmount`. In React, both go in a `useEffect`.
+
+## Trigger swap
+
+The `trigger` prop (or `#trigger` slot in Vue) is a render-prop:
+
+```tsx
+trigger={({ open, selected, toggle, close }) => (
+  <button onClick={toggle} aria-expanded={open}>
+    {selected?.label ?? 'Pick one'}
+  </button>
+)}
+```
+
+When `trigger` is provided, Select:
+
+- Does **not** render its default Textbox.
+- Wraps the consumer's node in the same wrapper element (so the popover anchors correctly).
+- Does **not** add ARIA attributes to the consumer's node — the consumer wires them via the render-prop context. Document this explicitly in `instructions.md`.
+
+This is a deliberate choice: trying to auto-wire ARIA onto an arbitrary node is fragile (cloneElement + attribute merging issues). Pushing it to the consumer keeps the contract clean.
+
+## Rendering `type: 'custom'` rows
+
+`CustomItem.render(ctx)` is called inside the row container — Select still owns the row chrome (height, padding, hover styles), the consumer only fills the content. `ctx.selected` lets them mirror the selected state visually.
+
+`value` is optional on custom items: if provided, the row is selectable; if omitted, the row behaves like `headline` (non-selectable, skipped during keyboard traversal).
+
+## Extension points
+
+- New content type → add a discriminated union variant to `SelectItem` in constants, add a branch in `SelectOptionItem`, add classes to `CssOptionItemTypeClasses` if structural changes are needed. Update the keyboard-traversal "selectable types" allowlist in Select.
+- New state → edit the relevant variant class string in `option-item-classes.ts`. Do not add a new constants key per state.
+- New theme → add a `${theme}-default` entry to every theme-keyed constant.
+
+## Planned / potential work
+
+- Multi-select (`multiple` prop). Would change `value` to `string[]` and keep the popover open after click.
+- Radio content type — blocked on a shared Radio component.
+- Floating UI integration for collision-aware popover placement.
+- Virtualization for very long lists.
+- Async / fuzzy filtering hooks.

--- a/components/Select/instructions.md
+++ b/components/Select/instructions.md
@@ -241,7 +241,6 @@ The Figma defines sizes `32` and `40` for the Option Item. Select forwards the s
 
 ## References
 
-- [Live demo](./ReadMe.md) renders on the design system site.
 - Light mode Figma: https://www.figma.com/design/1DRMyEt2idRzHMmV0NTA3O/Component---Inputs-v1.0----latest?node-id=5020-18440
 - Dark mode Figma: https://www.figma.com/design/1DRMyEt2idRzHMmV0NTA3O/Component---Inputs-v1.0----latest?node-id=5116-122756
 - Implementation details: [`architecture.md`](./architecture.md)

--- a/components/Select/instructions.md
+++ b/components/Select/instructions.md
@@ -76,7 +76,7 @@ The footer is rendered below the items when at least one footer prop is set.
 
 ### Trigger
 
-- **`trigger`** — `ReactNode | ((ctx) => ReactNode)` (React) / slot `#trigger="{ ctx }"` (Vue). Escape hatch to replace the default Textbox trigger. The render context (`ctx`) exposes `{ open: boolean, selected: SelectItem | null, toggle: () => void, close: () => void }`. The consumer is responsible for calling `toggle()` or `close()` on whatever element they render; Select still owns the popover.
+- **`trigger`** — `ReactNode | ((ctx) => ReactNode)` (React) / slot `#trigger="{ ctx }"` (Vue). Escape hatch to replace the default Button trigger. The render context (`ctx`) exposes `{ open: boolean, selected: SelectItem | null, toggle: () => void, close: () => void }`. The consumer is responsible for calling `toggle()` or `close()` on whatever element they render; Select still owns the popover.
 
 ### Extension
 
@@ -193,7 +193,7 @@ interface CustomItem {
 
 ## Slots (Vue only)
 
-- **`#trigger="{ open, selected, toggle, close }"`** — replace the default Textbox trigger.
+- **`#trigger="{ open, selected, toggle, close }"`** — replace the default Button trigger.
 - **`#footer`** — arbitrary footer content (takes precedence over `footerLabel` / `footerAction`).
 - **`#header-extra`** — additional content rendered inside the header below the title / tabs / search (rare).
 
@@ -210,11 +210,7 @@ The Option Item responds to the following states (all visible in the Figma):
 
 State priority: `disabled` > `focus-visible` > `active` > `hover` > `selected` > `default`.
 
-The Trigger inherits Textbox's states (`default`, `hover`, `focused`, `focus-visible`, `disabled`) and adds an open-popover state that mirrors `focus-within`.
-
-## Sizes
-
-The Figma defines sizes `32` and `40` for the Option Item. Select forwards the same `size` to its trigger, so the trigger and rows always match. `48` is accepted as a passthrough to Textbox for the trigger but the rows render at `40` in that case (the Figma does not specify a `48` row).
+The Trigger inherits Button's states (`default`, `hover`, `focused`, `focus-visible`, `disabled`) and adds an open-popover state that mirrors `focus-within`.
 
 ## Accessibility
 

--- a/components/Select/instructions.md
+++ b/components/Select/instructions.md
@@ -1,0 +1,237 @@
+# Select — usage
+
+How to use the Select component. Anything documented here is supported; anything missing isn't.
+
+## What it is
+
+A single-select dropdown. The trigger is a [`Textbox`](../Textbox/instructions.md)-styled control by default, but can be swapped for any other element (e.g. a [`Button`](../Button/instructions.md)). The popover panel ("Option List") shows a list of rows ("Option Items") of several content types, with optional header (title, tabs, search) and footer.
+
+Select composes existing cypress-design primitives — Textbox, Tabs, Checkbox, Tag, Button, Icon — so consumers get a consistent look without taking a dependency on `react-select` or other third-party dropdown libraries.
+
+## Install
+
+```bash
+yarn add @cypress-design/vue-select         # Vue
+yarn add @cypress-design/react-select       # React
+yarn add @cypress-design/constants-select   # shared types (SelectItem, etc.)
+```
+
+## Props
+
+All props are optional unless noted. React and Vue expose the same prop surface, with framework-idiomatic differences called out per prop. Vue uses kebab-case for attribute names and binds the value via `v-model` (mapped to `modelValue`) and the open state via `v-model:open`.
+
+### Selection & data
+
+- **`items`** — `SelectItem[]`, **required**. The list of rows to render. See "Item shapes" below.
+- **`value`** — `string`. Controlled selected value (must match an item's `value`).
+  - React: controlled prop. If omitted (and `defaultValue` is also omitted), the component is uncontrolled.
+  - Vue: optional override that takes precedence over `modelValue`. Most callers should use `v-model` / `modelValue` instead.
+- **`defaultValue`** — `string` (React only). Uncontrolled initial value.
+- **`modelValue`** — `string` (Vue only). Bound via `v-model`. Updates are emitted through `update:modelValue`.
+- **`onChange`** — `(value: string, item: SelectItem) => void` (React). Vue uses `@update:modelValue`.
+- **`placeholder`** — `string`. Shown on the default trigger when nothing is selected.
+
+### Appearance
+
+- **`theme`** — `'light' | 'dark'`, default `'light'`. Visual theme. Applied to both the trigger and the popover.
+- **`size`** — `'32' | '40'`, default `'40'`. Height (in pixels, as a string) of the default trigger and of each option row.
+- **`variant`** — `'default' | 'valid' | 'invalid' | 'warning'`, default `'default'`. Forwarded to the default Textbox trigger. `'invalid'` auto-sets `aria-invalid="true"` on the trigger unless overridden.
+- **`align`** — `'left' | 'right'`, default `'left'`. Horizontal alignment of the popover relative to the trigger. `'left'` aligns the popover's left edge to the trigger's left edge; `'right'` aligns the right edges.
+- **`disabled`** — `boolean`, default `false`. Disables the trigger and prevents opening the popover.
+
+### Open / close state
+
+- **`defaultOpen`** — `boolean`, default `false`. Uncontrolled initial open state. The Figma "Dropdown visibility" toggle maps to this.
+- **`open`** — `boolean`. Fully controlled open state. Pair with `onOpenChange`.
+- **`onOpenChange`** — `(open: boolean) => void`. Fires when the popover opens or closes (whether controlled or uncontrolled).
+
+### Header
+
+The header is rendered above the items when at least one header prop is set.
+
+- **`headerTitle`** — `string`. Section heading at the top of the popover.
+- **`headerTabs`** — `Tab[]`. Renders a [`Tabs`](../Tabs/instructions.md) row inside the header. Use with `headerActiveTab` and `onHeaderTabChange`.
+- **`headerActiveTab`** — `string`. ID of the currently active tab. Controlled.
+- **`onHeaderTabChange`** — `(id: string) => void`. Fired when the user switches tabs.
+- **`searchable`** — `boolean`, default `false`. Renders a search [`Textbox`](../Textbox/instructions.md) in the header. The current input value filters `items` by case-insensitive substring match against each item's `label`.
+- **`searchPlaceholder`** — `string`, default `'Search'`. Placeholder for the search Textbox.
+
+### Footer
+
+The footer is rendered below the items when at least one footer prop is set.
+
+- **`footer`** — `ReactNode | string` (React) / slot `#footer` (Vue). Arbitrary footer content. Takes precedence over the shorthand props below.
+- **`footerLabel`** — `string`. Shorthand: shows a left-aligned label inside the footer row.
+- **`footerAction`** — `{ label: string; onClick: () => void }`. Shorthand: shows a right-aligned action button using cypress-design's Button.
+
+### Trigger
+
+- **`trigger`** — `ReactNode | ((ctx) => ReactNode)` (React) / slot `#trigger="{ ctx }"` (Vue). Escape hatch to replace the default Textbox trigger. The render context (`ctx`) exposes `{ open: boolean, selected: SelectItem | null, toggle: () => void, close: () => void }`. The consumer is responsible for calling `toggle()` or `close()` on whatever element they render; Select still owns the popover.
+
+### Extension
+
+- **`className`** — applied to the outer wrapper element.
+- **`popoverClassName`** — applied to the popover panel.
+
+## Item shapes
+
+`items` is a discriminated union. The `type` field picks the row content. Required fields differ per type.
+
+```ts
+type SelectItem =
+  | DefaultItem
+  | HeadlineItem
+  | DividerItem
+  | CheckboxItem
+  | UserItem
+  | ButtonItem
+  | CustomItem
+```
+
+### `default` (selectable)
+
+```ts
+interface DefaultItem {
+  type?: 'default' // default when type is omitted
+  value: string // selection key; emitted via onChange
+  label: string // primary text
+  iconLeft?: IconNode // any Icon component or React/Vue node
+  slotRight?: ReactNode // right-side slot: icon, button, switch, etc.
+  tag?: string | TagProps // small Tag rendered after the label
+  disabled?: boolean
+}
+```
+
+### `headline` (non-selectable)
+
+```ts
+interface HeadlineItem {
+  type: 'headline'
+  label: string // rendered as a section heading
+}
+```
+
+### `divider` (non-selectable)
+
+```ts
+interface DividerItem {
+  type: 'divider'
+}
+```
+
+### `checkbox` (selectable, single-select)
+
+Visual affordance only — the row shows a Checkbox that mirrors the row's selected state. Clicking the row sets it as the selected value (Select remains single-select; the checkbox does not toggle independently).
+
+```ts
+interface CheckboxItem {
+  type: 'checkbox'
+  value: string
+  label: string
+  subText?: string // secondary text rendered under the label
+  disabled?: boolean
+}
+```
+
+### `user` (selectable)
+
+Avatar + name + secondary text (e.g. email or SSO provider). The avatar is whatever Icon node the consumer passes via `iconLeft` — Select does not ship its own Avatar component.
+
+```ts
+interface UserItem {
+  type: 'user'
+  value: string
+  label: string // primary text (e.g. user name)
+  secondary?: string // secondary text (e.g. email — Enterprise SSO)
+  iconLeft?: IconNode
+}
+```
+
+### `button` (non-selectable, action row)
+
+```ts
+interface ButtonItem {
+  type: 'button'
+  key: string // stable React/Vue key
+  label: string
+  onClick: () => void
+  variant?: ButtonVariant // forwarded to <Button>
+}
+```
+
+### `custom` (escape hatch)
+
+Full control over the row's interior. Useful for shapes the built-in types don't cover. Provide a `value` to make the row selectable; omit it for a non-selectable row.
+
+```ts
+interface CustomItem {
+  type: 'custom'
+  value?: string
+  render: (ctx: { selected: boolean }) => ReactNode
+}
+```
+
+## Events
+
+| Event                  | Payload                 | Description                                       |
+| ---------------------- | ----------------------- | ------------------------------------------------- |
+| `update:modelValue`    | `string`                | Vue — emitted whenever the selection changes      |
+| `update:open`          | `boolean`               | Vue — emitted whenever the popover opens / closes |
+| `change`               | `string, SelectItem`    | Vue — emitted whenever the selection changes      |
+| `onChange` (React)     | `(value, item) => void` | Selection changed                                 |
+| `onOpenChange` (React) | `(open) => void`        | Popover open state changed                        |
+
+## Slots (Vue only)
+
+- **`#trigger="{ open, selected, toggle, close }"`** — replace the default Textbox trigger.
+- **`#footer`** — arbitrary footer content (takes precedence over `footerLabel` / `footerAction`).
+- **`#header-extra`** — additional content rendered inside the header below the title / tabs / search (rare).
+
+## States
+
+The Option Item responds to the following states (all visible in the Figma):
+
+- `default` — base.
+- `hover` — mouse over the row.
+- `active` — mouse pressed on the row.
+- `selected` — row's `value` matches the current selection.
+- `focus-visible` — row received focus via keyboard (Tab or Arrow keys).
+- `disabled` — `item.disabled === true`. Overrides hover/active visuals.
+
+State priority: `disabled` > `focus-visible` > `active` > `hover` > `selected` > `default`.
+
+The Trigger inherits Textbox's states (`default`, `hover`, `focused`, `focus-visible`, `disabled`) and adds an open-popover state that mirrors `focus-within`.
+
+## Sizes
+
+The Figma defines sizes `32` and `40` for the Option Item. Select forwards the same `size` to its trigger, so the trigger and rows always match. `48` is accepted as a passthrough to Textbox for the trigger but the rows render at `40` in that case (the Figma does not specify a `48` row).
+
+## Accessibility
+
+- Trigger has `role="combobox"`, `aria-expanded`, `aria-controls` (pointing at the popover), `aria-haspopup="listbox"`.
+- Popover has `role="listbox"`.
+- Selectable rows have `role="option"` + `aria-selected`. Non-selectable rows (`headline`, `divider`, `button`) have `role="presentation"`.
+- Disabled rows have `aria-disabled="true"` (they are `<div>` elements, not `<button>` / `<input>`, so the HTML `disabled` attribute does not apply).
+- Focus inside the popover is tracked via `aria-activedescendant` on the trigger so the search Textbox keeps real DOM focus while ArrowUp / ArrowDown traverse the options.
+- Keyboard support:
+  - `Enter` / `Space` on the trigger → toggle open.
+  - `ArrowDown` on the trigger → open and focus the first selectable row.
+  - `ArrowUp` / `ArrowDown` inside the popover → previous / next selectable row (skips `headline`, `divider`, `button`, `disabled`).
+  - `Enter` on a focused row → select + close (selectable rows); fire `onClick` (`button` rows).
+  - `Escape` → close + return focus to the trigger.
+  - `Tab` → close and move focus naturally.
+
+## Known limitations
+
+- **Single-select only.** Multi-select (`multiple` prop, `value: string[]`) is reserved for a future version.
+- **No popover collision detection.** The popover renders below the trigger in the chosen `align` direction. If it would overflow the viewport, the consumer is responsible for changing `align` or placing the trigger differently. A Floating UI integration is out of scope for v1.
+- **No virtualization.** Lists with hundreds of items will render every row to the DOM.
+- **No `radio` content type yet.** The Figma defines a radio row but cypress-design does not ship a Radio component. Once a shared Radio lands, `SelectItem` will gain a `'radio'` variant.
+- **No built-in Avatar.** `type: 'user'` rows render whatever you pass via `iconLeft`. Pass an Icon component for a consistent look.
+
+## References
+
+- [Live demo](./ReadMe.md) renders on the design system site.
+- Light mode Figma: https://www.figma.com/design/1DRMyEt2idRzHMmV0NTA3O/Component---Inputs-v1.0----latest?node-id=5020-18440
+- Dark mode Figma: https://www.figma.com/design/1DRMyEt2idRzHMmV0NTA3O/Component---Inputs-v1.0----latest?node-id=5116-122756
+- Implementation details: [`architecture.md`](./architecture.md)

--- a/components/Select/instructions.md
+++ b/components/Select/instructions.md
@@ -4,9 +4,9 @@ How to use the Select component. Anything documented here is supported; anything
 
 ## What it is
 
-A single-select dropdown. The trigger is a [`Textbox`](../Textbox/instructions.md)-styled control by default, but can be swapped for any other element (e.g. a [`Button`](../Button/instructions.md)). The popover panel ("Option List") shows a list of rows ("Option Items") of several content types, with optional header (title, tabs, search) and footer.
+A single-select dropdown. The trigger is a [`Button`](../Button/instructions.md) by default (showing the selected label followed by a chevron icon), but can be swapped for any other element via the `trigger` slot. The popover panel ("Option List") shows a list of rows ("Option Items") of several content types, with optional header (title, tabs, search) and footer.
 
-Select composes existing cypress-design primitives — Textbox, Tabs, Checkbox, Tag, Button, Icon — so consumers get a consistent look without taking a dependency on `react-select` or other third-party dropdown libraries.
+Select composes existing cypress-design primitives — Button, Tabs, Checkbox, Textbox (for the search input), Tag, Icon — so consumers get a consistent look without taking a dependency on `react-select` or other third-party dropdown libraries.
 
 ## Install
 
@@ -35,9 +35,19 @@ All props are optional unless noted. React and Vue expose the same prop surface,
 
 - **`theme`** — `'light' | 'dark'`, default `'light'`. Visual theme. Applied to both the trigger and the popover.
 - **`size`** — `'32' | '40'`, default `'40'`. Height (in pixels, as a string) of the default trigger and of each option row.
-- **`variant`** — `'default' | 'valid' | 'invalid' | 'warning'`, default `'default'`. Forwarded to the default Textbox trigger. `'invalid'` auto-sets `aria-invalid="true"` on the trigger unless overridden.
+- **`triggerVariant`** — `ButtonVariant`, default `'outline-gray'`. Forwarded to the default Button trigger. See [Button instructions](../Button/instructions.md) for the full set of variants. Ignored when a custom `trigger` slot is supplied.
 - **`align`** — `'left' | 'right'`, default `'left'`. Horizontal alignment of the popover relative to the trigger. `'left'` aligns the popover's left edge to the trigger's left edge; `'right'` aligns the right edges.
 - **`disabled`** — `boolean`, default `false`. Disables the trigger and prevents opening the popover.
+
+### Dropdown sizing
+
+These apply to the popover panel only — the trigger keeps its natural width. Accept any CSS length string (e.g. `'320px'`, `'20rem'`, `'100%'`) or a plain number (interpreted as pixels). Omit for natural sizing.
+
+- **`width`** — fixed width of the popover.
+- **`minWidth`** — minimum width.
+- **`maxWidth`** — maximum width.
+- **`height`** — fixed height. Pair with `maxHeight` only if you also want the list to scroll past that height; usually you only need `maxHeight`.
+- **`maxHeight`** — maximum height. When the rendered rows exceed this, the items area scrolls. Headers and footers stay pinned.
 
 ### Open / close state
 


### PR DESCRIPTION
## Summary

Stage 1 of 4 for porting cypress-services' `SingleSelect` (built on `react-select`) into cypress-design as a new `Select` component. This PR is **docs only** — it lays out the public API, item shapes, states, accessibility model, and implementation notes so reviewers can sign off on the surface before any code is written.

- `components/Select/instructions.md` — consumer-facing usage doc (props, events, item shapes, states, accessibility, known limitations).
- `components/Select/architecture.md` — implementation notes (file layout, composition over invention, state ownership, constants keying, popover positioning, filtering, click-outside/ESC, trigger swap, extension points).
- `.agents/index.md` — registers `Select` in the component list.

## Stacked-PR series

This PR is the base of a four-PR stack. Each subsequent PR bases on the previous and merges together when the whole component is ready.

1. **`select-instructions` → `main` (this PR)** — docs only.
2. `select-component` → `select-instructions` — constants, React + Vue components, demo.
3. `select-tests` → `select-component` — Cypress component tests, Percy snapshots.
4. `select-accessibility` → `select-tests` — final ARIA + keyboard polish.

## Key API decisions captured in the docs

- **Built natively** (no `react-select`). Composes existing primitives: Textbox (trigger + search), Tabs (header), Checkbox (`checkbox` row), Button (`button` row), Tag, Icon.
- **Hybrid row API** — typed `type` field (`default | headline | divider | checkbox | user | button | custom`) with a `custom.render` escape hatch.
- **Single-select v1.** Multi-select reserved for v2 via a future `multiple` prop.
- **Default Textbox trigger + `trigger` render-prop / slot escape hatch.**
- **Header / footer** — slots (`#footer`, `#trigger`) plus structured shorthands (`headerTitle`, `headerTabs`, `searchable`, `footerLabel`, `footerAction`).
- **Alignment** — `align: 'left' | 'right'`. No collision detection (out of scope for v1).
- **No `radio` row in v1** — blocked on a shared Radio component landing in cypress-design.
- **ARIA combobox + listbox pattern**, focus tracked via `aria-activedescendant` so the search Textbox keeps real DOM focus while arrows traverse rows.

## Test plan

- [ ] Confirm props, events, states match the Figma spec ([light mode](https://www.figma.com/design/1DRMyEt2idRzHMmV0NTA3O/Component---Inputs-v1.0----latest?node-id=5020-18440), [dark mode](https://www.figma.com/design/1DRMyEt2idRzHMmV0NTA3O/Component---Inputs-v1.0----latest?node-id=5116-122756)).
- [ ] Confirm the public API will let cypress-services replace its existing deep-path `SingleSelect` import without behavior regression for `ArtifactControls`, replay pickers, and `TabBar` overflow.
- [ ] Sanity-check that `architecture.md` decisions (JS-driven focus, no `react-select`, no Floating UI in v1) align with reviewer expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no production code, tests, or runtime behavior.
> 
> **Overview**
> **Stage 1 (docs only)** for a new design-system **Select** that will replace cypress-services’ `react-select`-based `SingleSelect`. No runtime code in this PR—reviewers sign off on the API and build plan before implementation lands in follow-up PRs.
> 
> Adds **`components/Select/instructions.md`**: consumer contract—props/events, discriminated **`SelectItem`** row types (`default`, `headline`, `divider`, `checkbox`, `user`, `button`, `custom`), optional header (title/tabs/search) and footer, swappable **`trigger`**, single-select v1, and **combobox + listbox** accessibility (keyboard, `aria-activedescendant`, known v1 limits).
> 
> Adds **`components/Select/architecture.md`**: planned React/Vue layout, composition via existing **Button**, **Tabs**, **Textbox**, **Checkbox**, **Tag**, **Icon**; state owned in **`Select`** (open, value, search, focused index); JS-driven row focus; filtering and popover sizing/positioning; extension points.
> 
> Updates **`.agents/index.md`** to register **Select** in the agent component index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ac53021193640eec0fbda918b6efee7c7f05b8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->