### PR TITLE
docs(principles): add "Apply the principle; don't cite it" to feedback.md

### DIFF
--- a/.agents/principles/feedback.md
+++ b/.agents/principles/feedback.md
@@ -17,6 +17,8 @@ description: Principles for reviewing other people's work and giving design / pr
 
 **Number feedback that needs to be acted on.** Scannable, numbered lists travel better than prose blocks. Bury context underneath each numbered point, not on top of the list.
 
+**Apply the principle; don't cite it.** Ground feedback in the principle, then build it into clear, plain advice — don't quote chapter-and-verse to an audience that isn't fluent in the design system. Naming the rule adds ceremony, not weight; being consistent and clear is what makes it land. Reserve exact quoting for the internal check with the principle's owner, where it has to be verifiable. Linking to the source can come later, once it's shared vocabulary.
+
 **Time-box design, but don't pretend it's instant.** Things always take longer once you're inside them. Over-committing on timelines punishes the work and produces worse outcomes; honest estimates protect quality.
 
 ## Related


### PR DESCRIPTION
Adds one principle to `.agents/principles/feedback.md`:

> **Apply the principle; don't cite it.** Ground feedback in the principle, then build it into clear, plain advice — don't quote chapter-and-verse to an audience that isn't fluent in the design system. Naming the rule adds ceremony, not weight; being consistent and clear is what makes it land. Reserve exact quoting for the internal check with the principle's owner, where it has to be verifiable. Linking to the source can come later, once it's shared vocabulary.

**Origin:** emerged from feedback on a cy.prompt beta→GA billing reply — the explicit principle labels and quotes were stripped, keeping only plain claims. Staged via the living-document workflow in [cypress-io/cypress.io#2517](https://github.com/cypress-io/cypress.io/pull/2517) (`.agents/design-principles-proposals.md`); wording approved by Ryan in chat.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-agent-docs edit with no application, security, or data impact.
> 
> **Overview**
> Adds a new guideline to `.agents/principles/feedback.md`: **Apply the principle; don't cite it.** Reviewers should turn principles into plain, actionable advice instead of quoting design-system rules to audiences that aren’t fluent in them; reserve verbatim citations for internal verification with the principle owner, with links optional once vocabulary is shared.
> 
> Docs-only; no runtime or product code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b692638727343beea69eaf80536ede71a7a2480. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->