### PR TITLE
chore: add PR template that leads with why/what over how

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+<!-- Lead with the problem, not the implementation. Reviewers — human and AI — give
+     better feedback when they know the goal. The why/what matters more than the how. -->
+
+## What & why
+
+<!-- The problem this solves and why it matters. What's the goal?
+     For principles/docs: what feedback or real situation prompted this, and what should
+     a reader now do differently? -->
+
+## How
+
+<!-- The approach — only if the diff isn't self-explanatory. -->
+
+## Where to focus review
+
+<!-- Point reviewers at the goal, not the syntax. e.g. "Does this conflict with or
+     duplicate an existing principle?" "Is the wording grounded in the actual feedback?" -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,8 @@ Before doing any work, you MUST read:
 
 Before claiming any UI / visual / content task is done, run `/.agents/review-checklist.md` against your own diff.
 
+When opening a PR, lead the description with the problem and goal (why / what) before the implementation (how) — see [`.github/pull_request_template.md`](.github/pull_request_template.md). Reviewers, human and AI, evaluate against the stated goal; a description that's all _how_ steers them toward syntax nitpicks instead of substance.
+
 Everything under `/.agents/` is also served at `https://design.cypress.io/agents/` for consumer repos to fetch — same files, single source of truth.
 
 ## Component files


### PR DESCRIPTION
<!-- This PR introduces the template below; its own description is written to model it. -->

## What & why

PRs in this repo have no description convention, and the agent guidance never said what a good PR description should contain. The cost shows up in review: when a diff arrives without its goal stated, reviewers — Copilot especially — default to syntax and punctuation nitpicks, because local correctness is all they can judge without the *why*.

Concrete evidence from **#671** (three pricing principles): across two Copilot review rounds, **every** comment was a quote-punctuation nitpick on a cross-reference, and **zero** touched the substance (do the principles conflict, are they grounded in real feedback):

- #671 comment 1 — `ux.md`, nested quotes in a cross-link (`databaseId 3326130425`, resolved, fixed in `e3ed8e58`)
- #671 comment 2 — `releases.md`, trailing comma inside a quoted phrase (`databaseId 3326246563`, resolved, fixed in `dd6113de`)

Both fixes were legitimate, but they're linter-grade — not the ceiling of a review.

**Root cause:** Copilot reviews the **diff, locally**. Principle/prose quality is a **global, semantic** property (does this conflict with the other ~90 principles; is it grounded in the originating feedback) — and Copilot has neither the full corpus nor that feedback in context, so it falls back to what it *can* grade from the diff alone: syntax.

**Goal:** make every PR carry enough goal-context that reviewers — Copilot, teammates, future-you reading git blame — evaluate against the problem instead of comma-hunting. A good description helps *every* reviewer, which is strictly better leverage than Copilot-only custom instructions.

## How

- Add `.github/pull_request_template.md` — three short sections (**What & why** → **How** → **Where to focus review**). Kept short on purpose; long templates get deleted. The "Where to focus" section is the lever: it lets the author point reviewers at the real risk up front (e.g. "does this conflict with an existing principle?").
- Add a one-line convention to `AGENTS.md` so agents opening PRs follow it. (`AGENTS.md` and everything under `.agents/` is served to consumer repos at design.cypress.io/agents — but the PR template is repo-local GitHub infra, not part of that served bundle.)

## Where to focus review

1. **Template wording / section headers** — you'll see these on every PR; do the three headers earn their place, or is one redundant?
2. **Is `AGENTS.md` the right home** for the convention, or should it live somewhere more contributor-facing (a `CONTRIBUTING.md`, which this repo doesn't currently have)?

## Decisions already made (please don't re-litigate without reason)

- **Not added as a design principle.** "Why over how" rhymes hard with existing corpus principles ("Build against the outcome, not the literal request"; "Name the business goal alongside the JTBD"). Adding a principle would trigger the exact "book full of duplicative principles" problem the `/review` workflow guards against — so it's a *workflow convention*, living with the template + agent guidance, not the principles corpus.
- **Its own PR, not folded into #671** — unrelated to the pricing principles; keeps that diff clean.
- **Copilot custom instructions considered, not done.** A `.github/instructions/*.instructions.md` file would *cut noise* but not *manufacture substance* Copilot structurally can't produce. Viable follow-up if noise persists.

## How to verify

- Template is plain markdown + HTML comments — renders as the default body the next time anyone opens a PR. Not browser-previewable; confirm by starting a new PR and checking the body pre-populates.
- `AGENTS.md` change is a single added paragraph; diff is self-explanatory.
- No tests, no build impact.

## Related

- Originating PR: #671
- Branch `chore/pr-template-why-over-how`, commit `c72c73f4`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and GitHub template only; no product code, auth, or runtime behavior.
> 
> **Overview**
> Introduces a **GitHub PR description convention** so reviewers (including AI) can judge changes against stated goals instead of only local diff details.
> 
> Adds **`.github/pull_request_template.md`** with three short sections—**What & why**, **How**, and **Where to focus review**—plus HTML comments nudging authors to lead with problem and goal. Updates **`AGENTS.md`** with a single paragraph telling agents opening PRs to follow the same why/what-before-how pattern and linking to the template.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57aa5176fa24a41b061cdba7acd6c0e88c3e5816. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->