### PR TITLE
docs(voice): add "Leading with value" — lead with the benefit, active voice

### DIFF
--- a/.agents/voice.md
+++ b/.agents/voice.md
@@ -25,3 +25,8 @@ description: Fetch when writing user-facing copy — UI strings, error messages,
 ## Headings
 
 - Headings pull people in; they don't label a shelf. Bias toward action- or outcome-oriented phrasing ("Catch failures before they ship") over dry category labels ("Workflows and integrations"). Category labels read as inert; action-oriented headings tell the reader why to keep reading.
+
+## Leading with value
+
+- **Lead with the benefit, not the mechanism.** Open with the outcome the reader gets, or the problem it removes — then name the feature that delivers it. The reader decides whether to care based on the "why"; the "what" earns its place once they do. Keep the mechanism in the second clause or the link-out, never the lead. ("Spend less time fixing accessibility violations by hand" before "Cloud MCP exposes accessibility report data.")
+- **Stay in active voice, addressed to the reader.** The reader — or something working on their behalf — is the subject doing or receiving the benefit: "your AI agent ranks what matters", not "violations are ranked". Passive constructions bury who acts and drain the sentence of momentum.


### PR DESCRIPTION
## What

New "Leading with value" section in `voice.md`, extending the existing **Headings** rule to body copy:

- **Lead with the benefit, not the mechanism** — open with the outcome or the problem removed, then name the feature. Mechanism goes in the second clause or the link-out, never the lead.
- **Stay in active voice, addressed to the reader** — "your AI agent ranks what matters", not "violations are ranked".

## Why

The Headings rule ("action-oriented over category labels") already captures this for headlines; copy reviews keep surfacing the same issue in body copy, where drafts open with the mechanism ("Cloud MCP exposes report data") instead of the payoff. Codifying it gives release/marketing copy a single rule to anchor on.

Surfaced while writing the Cloud MCP accessibility-support release entry on cypress.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to internal voice guidelines; no runtime or product behavior impact.
> 
> **Overview**
> Adds a **Leading with value** section to the voice agent guide, extending headline guidance into body and marketing copy.
> 
> Copy should open with the reader’s outcome or problem removed, then name the feature or mechanism. Sentences should stay active and second-person (e.g. what *your* agent does), avoiding passive, mechanism-first leads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bbe097a88392a1ab85cba88a517650e3ac29c50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->