### PR TITLE
docs(voice): lead body copy on the verb; avoid generic heading verbs

### DIFF
--- a/.agents/voice.md
+++ b/.agents/voice.md
@@ -25,8 +25,12 @@ description: Fetch when writing user-facing copy — UI strings, error messages,
 ## Headings
 
 - Headings pull people in; they don't label a shelf. Bias toward action- or outcome-oriented phrasing ("Catch failures before they ship") over dry category labels ("Workflows and integrations"). Category labels read as inert; action-oriented headings tell the reader why to keep reading.
+- Make the verb do work. A heading's verb is its most prominent word — don't spend it on a generic opener like "Get", "Use", or "Discover" that could front any heading. Reach for the verb that names the specific action or payoff: "Ground your agent's responses in official docs" over "Get accurate answers from your agent".
 
 ## Leading with value
 
 - **Lead with the benefit, not the mechanism.** Open with the outcome the reader gets, or the problem it removes — then name the feature that delivers it. The reader decides whether to care based on the "why"; the "what" earns its place once they do. Keep the mechanism in the second clause or the link-out, never the lead. ("Spend less time fixing accessibility violations by hand" before "Cloud MCP exposes accessibility report data.")
 - **Stay in active voice, addressed to the reader.** The reader — or something working on their behalf — is the subject doing or receiving the benefit: "your AI agent ranks what matters", not "violations are ranked". Passive constructions bury who acts and drain the sentence of momentum.
+- **Open the sentence on the verb.** Lead body copy with the action the reader takes — don't start with the feature name or an "X is a…" definition that strands the benefit behind the mechanism. "Ask your coding agent any Cypress question and trust the answer" beats "`cypress-docs` is a new skill that…". Each sentence should earn its momentum from the first word:
+  > Wind back the clock to any point in an application's execution and see exactly what it was doing during the point of failure. Inspect the DOM, network events, and console logs of your application from your tests exactly as they ran in CI.
+  > Review videos, screenshots, and logs for every spec file from any CI test run.


### PR DESCRIPTION
## What

Two `voice.md` refinements, captured from feedback during a release-copy review.

**Headings** — add a caution against generic, load-bearing-but-empty verbs:
> Make the verb do work. A heading's verb is its most prominent word — don't spend it on a generic opener like "Get", "Use", or "Discover" that could front any heading. Reach for the verb that names the specific action or payoff: "Ground your agent's responses in official docs" over "Get accurate answers from your agent".

**Leading with value** — sharpen the existing active-voice rule into a concrete, verb-first sentence instruction:
> **Open the sentence on the verb.** Lead body copy with the action the reader takes — don't start with the feature name or an "X is a…" definition that strands the benefit behind the mechanism.

## Why

The general "stay in active voice" rule was already here, but it didn't stop a release-copy draft from opening on a definition (`` `cypress-docs` is a new skill that… ``). The sharper "open on the verb" framing — plus worked examples — makes the failure mode explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to internal copy guidelines; no runtime or product code changes.
> 
> **Overview**
> Extends **`.agents/voice.md`** with two writer guidelines and examples.
> 
> Under **Headings**, adds guidance to avoid generic heading verbs (“Get”, “Use”, “Discover”) and to pick verbs that state the specific payoff, with a before/after example.
> 
> Under **Leading with value**, adds **Open the sentence on the verb**: lead body copy with the reader’s action, not feature-name or “X is a…” definitions, plus a good/bad pair and two blockquoted sample sentences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8928972d64d705257d61f9f17a2916c7082e5bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->