### PR TITLE
docs(voice): fold the team style guide into the voice + accessibility pillars

### DIFF
--- a/.agents/accessibility.md
+++ b/.agents/accessibility.md
@@ -34,7 +34,7 @@ Accessibility is a content concern, not only a design one. These rules apply whe
 **"Disabled" and "disability" are the correct words — don't tiptoe around them.** This language moves quickly, and we'll get corrected sometimes; stay open to it.
 
 - **Avoid:** "special needs", "differently abled", "people of all abilities", "wheelchair-bound", "normal" / "regular" people, "inspiring" / "inspirational" (when applied to people for being disabled).
-- **Prefer, by context:** "people with disabilities", "disabled people", "blind", "deaf", "non-speaking", "non-disabled", "sighted", "mouse-users", "screen-reader users".
+- **Prefer, by context:** "people with disabilities", "disabled people", "blind", "deaf", "non-speaking", "non-disabled", "sighted", "mouse users", "screen-reader users".
 - **Defer to a person's own preference** when you know it — e.g. capital-D "Deaf", or a stated preference like "hearing impaired". There's no way to know ahead of time, so don't assume.
 - **Name the technical need, not the disability, when being specific.** Screen readers aren't used only by blind people — say "screen-reader users" when that's who you mean, and reserve "blind users" for what's genuinely specific to blind people (which is rarer than it seems).
 

--- a/.agents/accessibility.md
+++ b/.agents/accessibility.md
@@ -1,6 +1,6 @@
 ---
 name: accessibility
-description: Accessibility principles and considerations. Fetch when designing interactive elements, modals, custom inputs, animations, or evaluating whether a flow works for users on keyboard / assistive tech.
+description: Accessibility principles and considerations. Fetch when designing interactive elements, modals, custom inputs, animations, evaluating whether a flow works for users on keyboard / assistive tech, or writing copy about accessibility or disability.
 ---
 
 # Accessibility
@@ -23,7 +23,25 @@ When and how to invest in accessibility, plus the patterns that come up most oft
 
 **Don't trap users in inaccessible flows.** Modals, dropdowns, carousels, and custom inputs are where accessibility most often breaks. Test them with a keyboard and a screen reader before shipping — not after a customer files a ticket.
 
+## Writing about accessibility and disability
+
+Accessibility is a content concern, not only a design one. These rules apply whenever you write or format copy.
+
+**Don't rely on visuals alone.** If a reader can't see colors, images, or video, the core message must still land in the text. Provide alt text for informative images and mark decorative ones as decorative. Keep text and key UI at sufficient contrast for low-vision and color-blind readers.
+
+**Use descriptive link text.** A link must make sense on its own — "Read the Test Replay setup guide", never standalone "click here" or "learn more". (Errors and warnings share this rule; see [errors.md](./errors.md).)
+
+**"Disabled" and "disability" are the correct words — don't tiptoe around them.** This language moves quickly, and we'll get corrected sometimes; stay open to it.
+
+- **Avoid:** "special needs", "differently abled", "people of all abilities", "wheelchair-bound", "normal" / "regular" people, "inspiring" / "inspirational" (when applied to people for being disabled).
+- **Prefer, by context:** "people with disabilities", "disabled people", "blind", "deaf", "non-speaking", "non-disabled", "sighted", "mouse-users", "screen-reader users".
+- **Defer to a person's own preference** when you know it — e.g. capital-D "Deaf", or a stated preference like "hearing impaired". There's no way to know ahead of time, so don't assume.
+- **Name the technical need, not the disability, when being specific.** Screen readers aren't used only by blind people — say "screen-reader users" when that's who you mean, and reserve "blind users" for what's genuinely specific to blind people (which is rarer than it seems).
+
+When in doubt, check the [accessibility.com glossary](https://www.accessibility.com/glossary). Deeper references: the [NCDJ Disability Language Style Guide](https://ncdj.org/style-guide/) and the [University of Iowa DEI style guide](https://diversity.uiowa.edu/resources/dei-style-guide/style-guide-people-disabilities).
+
 ## Related
 
+- [voice.md](./voice.md) — general voice, tone, and mechanics for all copy
 - [colors.md](./colors.md) — Contrast tokens
 - [review-checklist.md](./review-checklist.md) — Mechanical a11y checks before shipping

--- a/.agents/index.md
+++ b/.agents/index.md
@@ -27,7 +27,7 @@ Several pillars lead with a `## Principles` section that governs the tokens and 
 - [spacing.md](./spacing.md) — margins, padding, gaps, layout dimensions
 - [iconography.md](./iconography.md) — creating or styling icons
 - [illustrations.md](./illustrations.md) — illustration principles, style, theme, and guidelines
-- [voice.md](./voice.md) — UI copy, tone, point of view, capitalization, product naming, mechanics (numbers, dates, punctuation)
+- [voice.md](./voice.md) — UI copy, errors, empty states, tone, capitalization, product naming, mechanics (numbers, dates, punctuation)
 - [errors.md](./errors.md) — errors, warnings, deprecations, and other system-to-user failure messages; distilled from the cypress-error-messages skill in aihub
 - [personas.md](./personas.md) — who uses Cypress and what they need
 - [accessibility.md](./accessibility.md) — when to invest in a11y and the patterns to follow on the surfaces you ship

--- a/.agents/index.md
+++ b/.agents/index.md
@@ -27,7 +27,7 @@ Several pillars lead with a `## Principles` section that governs the tokens and 
 - [spacing.md](./spacing.md) — margins, padding, gaps, layout dimensions
 - [iconography.md](./iconography.md) — creating or styling icons
 - [illustrations.md](./illustrations.md) — illustration principles, style, theme, and guidelines
-- [voice.md](./voice.md) — UI copy, errors, empty states
+- [voice.md](./voice.md) — UI copy, tone, point of view, capitalization, product naming, mechanics (numbers, dates, punctuation)
 - [errors.md](./errors.md) — errors, warnings, deprecations, and other system-to-user failure messages; distilled from the cypress-error-messages skill in aihub
 - [personas.md](./personas.md) — who uses Cypress and what they need
 - [accessibility.md](./accessibility.md) — when to invest in a11y and the patterns to follow on the surfaces you ship

--- a/.agents/voice.md
+++ b/.agents/voice.md
@@ -68,7 +68,7 @@ People skim before they commit. Write so the structure carries the meaning on a 
 ## Abbreviations and acronyms
 
 - Spell out acronyms on first use unless universally known (API, CSS).
-- Prefer "accessibility" over "a11y" in most contexts.
+- Prefer "accessibility" over "a11y" in user-facing copy. "a11y" is fine in internal labels, code, anchors, and checklists.
 - Use the shortened form consistently after first use.
 
 ## Headings
@@ -88,7 +88,7 @@ People skim before they commit. Write so the structure carries the meaning on a 
 ## Mechanics
 
 - **Numbers.** Spell out one through nine; use numerals for 10 and above. Always use numerals for metrics, measurements, and performance data.
-- **Dates and time.** Spell out days; abbreviate months. Use numerals with am/pm (7am, 7:30pm). Include time zones when scheduling matters.
+- **Dates and time.** Spell out the day of the week and abbreviate the month (Tuesday, Jan 14). Use numerals with am/pm (7am, 7:30pm). Include time zones when scheduling matters.
 - **Punctuation.** Use the serial (Oxford) comma. Use a colon to introduce a list. Use em dashes sparingly. Never use exclamation points in error messages or alerts — see [errors.md](./errors.md).
 
 ## Writing about accessibility and inclusion

--- a/.agents/voice.md
+++ b/.agents/voice.md
@@ -90,7 +90,6 @@ People skim before they commit. Write so the structure carries the meaning on a 
 - **Numbers.** Spell out one through nine; use numerals for 10 and above. Always use numerals for metrics, measurements, and performance data.
 - **Dates and time.** Spell out days; abbreviate months. Use numerals with am/pm (7am, 7:30pm). Include time zones when scheduling matters.
 - **Punctuation.** Use the serial (Oxford) comma. Use a colon to introduce a list. Use em dashes sparingly. Never use exclamation points in error messages or alerts — see [errors.md](./errors.md).
-- **Active voice by default.** "Cypress added support for hover interactions", not "Support for hover interactions was added". Reach for passive only when the actor genuinely doesn't matter.
 
 ## Writing about accessibility and inclusion
 

--- a/.agents/voice.md
+++ b/.agents/voice.md
@@ -5,22 +5,72 @@ description: Fetch when writing user-facing copy — UI strings, error messages,
 
 # Voice
 
+Clarity over comfort. Evidence over enthusiasm. Trust over tone. External communication is part of the product — treat it with the same rigor as code. The goal is never polish for its own sake; it's confidence through clarity.
+
+## Before you write
+
+Be explicit about four things before drafting any user-facing content:
+
+- **Audience** — who is this for, and how familiar are they with Cypress?
+- **Goal** — what should the reader understand or decide after reading?
+- **Main takeaway** — what stays clear if they only skim?
+- **Why it matters** — what cost, risk, effort, or uncertainty does this remove?
+
+Lead with reader benefit; the action you want follows from understanding. See [Leading with value](#leading-with-value).
+
 ## Tone
 
 - Confident, technical, concise. Speak like a senior engineer who respects the reader's time.
 - No hype, no marketing fluff. Avoid "simply", "just", "easy", "powerful", "seamless", "delight".
 - Prefer present tense, active voice.
+- **Match register to stakes.** The voice stays constant; the register tightens as stakes rise. More instructional for tutorials and learning; calm and direct for product changes; serious and precise for security, reliability, and deprecations. Clarity always outranks personality.
 - For errors, warnings, and deprecation messages specifically — stricter rules apply (no exclamation points, no blame, structured what/why/next). See [errors.md](./errors.md).
 
 ## Point of view
 
 - Address the reader as "you". Refer to the product as "Cypress".
-- Avoid "we" in product UI; reserve it for blog posts and marketing.
+- **"We" is for storytelling surfaces — blog posts, social, newsletters, announcements — where Cypress narrates to an audience.** Everywhere the product acts or the text is reference — product UI, error messages, docs, and release notes / changelog — use product voice: "Cypress now supports hover interactions", not "We added support for hover interactions". Never refer to the product as "it".
+
+## Writing for people
+
+People skim before they commit. Write so the structure carries the meaning on a fast pass.
+
+- **Front-load the point.** Use the [inverted pyramid](https://en.wikipedia.org/wiki/Inverted_pyramid_(journalism)) — most important information first. Assume the reader stops at any point.
+- **Make structure visible.** Headings, subheads, and lists over walls of text. Short paragraphs, direct sentences.
+- **Plain language over academic phrasing.** Favor the everyday word. Breaking a strict grammar rule is fine when it improves clarity.
+- **Cut buzzwords and vague verbs.** "Use Cypress to automate your tests", not "leverage Cypress to automate your tests".
+- **Write for an international audience.** Avoid idioms, slang, and culturally specific phrases — prefer globally understandable terms.
+
+## Confidence and certainty
+
+- **Be direct about what we know; be explicit about uncertainty when it exists.** Never imply a guarantee where there isn't one.
+- **When behavior is probabilistic or evolving, say so.** This matters most for AI-powered features — don't frame AI as autonomous or magical, don't promise correctness without guardrails, and don't imply it replaces human judgment. For the principles behind building with AI, see [principles/ai.md](./principles/ai.md).
 
 ## Capitalization
 
 - Sentence case for buttons, headings, menu items, page titles. Not Title Case.
+- Proper product and feature names keep their capitalization inside sentence-case text (see [Product and feature names](#product-and-feature-names)).
 - Code identifiers stay verbatim — never rewrap or recase them.
+
+## Product and feature names
+
+Use sentence case in most contexts; avoid unnecessary capitalization. When capitalization is unclear, match how the term appears in the product UI.
+
+- **Cypress** — write "Cypress", never "Cypress.io". On non-Cypress domains, link the first mention to cypress.io. "Cypress" can mean the whole platform (app + Cloud); when explaining specific behavior, name the specific product.
+- **Cypress Cloud** — always capitalized; don't precede with "the".
+- **Cypress app** — lowercase "app" unless a format forces title case.
+- **Cypress Studio**, **Cypress Learn** — capitalized.
+- **Cypress End-to-End Testing**, **Cypress Component Testing** — capitalize when naming the product or UI entity; lowercase for the general practice.
+- **Test Replay** — capitalized.
+- **UI Coverage** — capitalized; never "UI Code Coverage".
+- **Cypress Accessibility** — capitalized. Reports are "Cypress Accessibility report" or "accessibility report" depending on specificity.
+- **Launchpad**, **Test Runner** (the specific feature, not the whole app), **Command Log** — capitalized.
+
+## Abbreviations and acronyms
+
+- Spell out acronyms on first use unless universally known (API, CSS).
+- Prefer "accessibility" over "a11y" in most contexts.
+- Use the shortened form consistently after first use.
 
 ## Headings
 
@@ -35,3 +85,26 @@ description: Fetch when writing user-facing copy — UI strings, error messages,
 - **Open the sentence on the verb.** Lead body copy with the action the reader takes — don't start with the feature name or an "X is a…" definition that strands the benefit behind the mechanism. "Ask your coding agent any Cypress question and trust the answer" beats "`cypress-docs` is a new skill that…". Each sentence should earn its momentum from the first word:
   > Wind back the clock to any point in an application's execution and see exactly what it was doing during the point of failure. Inspect the DOM, network events, and console logs of your application from your tests exactly as they ran in CI.
   > Review videos, screenshots, and logs for every spec file from any CI test run.
+
+## Mechanics
+
+- **Numbers.** Spell out one through nine; use numerals for 10 and above. Always use numerals for metrics, measurements, and performance data.
+- **Dates and time.** Spell out days; abbreviate months. Use numerals with am/pm (7am, 7:30pm). Include time zones when scheduling matters.
+- **Punctuation.** Use the serial (Oxford) comma. Use a colon to introduce a list. Use em dashes sparingly. Never use exclamation points in error messages or alerts — see [errors.md](./errors.md).
+- **Active voice by default.** "Cypress added support for hover interactions", not "Support for hover interactions was added". Reach for passive only when the actor genuinely doesn't matter.
+
+## Writing about accessibility and inclusion
+
+When your copy concerns accessibility, disability, or assistive technology — alt text, link text, color reliance, and the language to use (and avoid) when referring to people with disabilities — the content rules live in [accessibility.md](./accessibility.md), "Writing about accessibility and disability". Fetch it before writing that content.
+
+## Before you publish
+
+Confirm the reader can answer: what changed, why Cypress made this choice, whether it affects them, and what to do next — and that the content reduces uncertainty rather than adding it. If Support would have to interpret your intent, it isn't ready.
+
+## Related
+
+- [errors.md](./errors.md) — stricter overrides for errors, warnings, and deprecations
+- [accessibility.md](./accessibility.md) — content accessibility and disability language
+- [principles/ai.md](./principles/ai.md) — building, designing, and writing with AI
+- [principles/ux.md](./principles/ux.md) — where business goals meet user needs
+- [principles/releases.md](./principles/releases.md) — release titles and shipping stages

--- a/.agents/voice.md
+++ b/.agents/voice.md
@@ -58,7 +58,7 @@ Use sentence case in most contexts; avoid unnecessary capitalization. When capit
 
 - **Cypress** — write "Cypress", never "Cypress.io". On non-Cypress domains, link the first mention to cypress.io. "Cypress" can mean the whole platform (app + Cloud); when explaining specific behavior, name the specific product.
 - **Cypress Cloud** — always capitalized; don't precede with "the".
-- **Cypress app** — lowercase "app" unless a format forces title case.
+- **Cypress App** — capitalized; it's a proper name.
 - **Cypress Studio**, **Cypress Learn** — capitalized.
 - **Cypress End-to-End Testing**, **Cypress Component Testing** — capitalize when naming the product or UI entity; lowercase for the general practice.
 - **Test Replay** — capitalized.

--- a/.agents/voice.md
+++ b/.agents/voice.md
@@ -54,17 +54,16 @@ People skim before they commit. Write so the structure carries the meaning on a 
 
 ## Product and feature names
 
-Use sentence case in most contexts; avoid unnecessary capitalization. When capitalization is unclear, match how the term appears in the product UI.
+**Product and feature names are always capitalized** — they're proper names, even inside otherwise sentence-case text. (Sentence case, above, governs UI chrome and headings — not these names.) When capitalization is unclear, match how the term appears in the product UI. The general capability stays lowercase even when the product is capitalized: "Cypress Accessibility" the product, "an accessibility report" the artifact.
 
-- **Cypress** — write "Cypress", never "Cypress.io". On non-Cypress domains, link the first mention to cypress.io. "Cypress" can mean the whole platform (app + Cloud); when explaining specific behavior, name the specific product.
+- **Cypress** — write "Cypress", never "Cypress.io". On non-Cypress domains, link the first mention to cypress.io. "Cypress" can mean the whole platform (the App and Cloud); when explaining specific behavior, name the specific product.
 - **Cypress Cloud** — always capitalized; don't precede with "the".
-- **Cypress App** — capitalized; it's a proper name.
-- **Cypress Studio**, **Cypress Learn** — capitalized.
+- **Cypress App**, **Cypress Studio**, **Cypress Learn** — capitalized.
 - **Cypress End-to-End Testing**, **Cypress Component Testing** — capitalize when naming the product or UI entity; lowercase for the general practice.
 - **Test Replay** — capitalized.
 - **UI Coverage** — capitalized; never "UI Code Coverage".
 - **Cypress Accessibility** — capitalized. Reports are "Cypress Accessibility report" or "accessibility report" depending on specificity.
-- **Launchpad**, **Test Runner** (the specific feature, not the whole app), **Command Log** — capitalized.
+- **Launchpad**, **Test Runner** (the specific feature, not the whole Cypress App), **Command Log** — capitalized.
 
 ## Abbreviations and acronyms
 


### PR DESCRIPTION
## What & why

We had two style guides drifting apart: the external-facing **Cypress Style Guide** (Google Doc) the team writes against, and the in-repo agent guidance under `.agents/`. This pulls the Doc's rules into the repo so there's one source of truth — the one agents and consumer repos actually fetch.

Prompted by a review of the Doc against `voice.md`. The only real conflict was the "we" rule; the rest was either net-new mechanics the repo lacked or content the repo already had.

## How

- **`voice.md`** — added: a before-you-write framing (audience/goal/takeaway/why), *Writing for people* (inverted pyramid, scanning, plain language, "leverage"→"use", international audience), *Confidence and certainty* (incl. how to describe AI features in copy), the canonical product/feature naming list (Cypress Cloud, Cypress app, Test Replay, UI Coverage, …), acronyms, *Mechanics* (numbers, dates, punctuation, Oxford comma), and a before-you-publish gate. Scoped **"we"** to storytelling surfaces (blog/social/newsletters); product UI, errors, docs, and release notes use product voice ("Cypress now does X").
- **`accessibility.md`** — added *Writing about accessibility and disability* (alt text, descriptive links, don't-rely-on-visuals, and disability-language terminology: avoid "special needs"/"wheelchair-bound"/"inspirational", prefer "disabled people"/"screen-reader users", defer to stated preference). Widened the file description so agents fetch it for copy tasks.
- **`index.md`** — broadened the `voice.md` one-liner for discoverability.

Deliberate calls:
- **Kept the repo's austere voice** — dropped the Doc's "warm / sincere / empathetic" stable-voice traits rather than softening the existing tone.
- **Breadcrumbs over duplication** — accessibility and AI content live in their pillars; `voice.md` points to them so an agent writing that content gets routed to the right file.
- **Kept the repo's harder line on passive voice** — the Doc permits passive "when emphasizing the action over the actor"; the repo doesn't. Flagging in case reviewers prefer the Doc's stance.

## Where to focus review

- Does the **"we" scoping** (storytelling vs. product/release notes) match how the team actually wants release notes to read?
- Is the **disability-language terminology** correctly placed in `accessibility.md` rather than `voice.md`, and is the wording current?
- Any rule here that **conflicts with or duplicates** an existing principle I missed?

Doc-side follow-up (not in this PR): the Google Doc still needs two edits to stay consistent — scope its "we, not it" rule, and swap its active-voice example to "Cypress now supports hover interactions."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to agent guidance; no runtime code, auth, or data paths.
> 
> **Overview**
> This PR **consolidates the external Cypress Style Guide into in-repo agent guidance** so `.agents/` is the single source agents and consumer repos fetch.
> 
> **`voice.md`** gains planning and publishing discipline (**Before you write**, **Before you publish**), skimmable-structure rules (**Writing for people**), **Confidence and certainty** (including cautious AI copy), a canonical **Product and feature names** list, **Abbreviations**, and **Mechanics** (numbers, dates, punctuation). It **narrows when "we" is allowed** to storytelling surfaces and requires product voice ("Cypress…") in UI, docs, errors, and release notes. Accessibility/disability copy is **delegated** to `accessibility.md` via a short pointer section.
> 
> **`accessibility.md`** adds **Writing about accessibility and disability** (non-visual reliance, link text, terminology avoid/prefer, deferring to stated preference) and widens its fetch description for copy tasks.
> 
> **`index.md`** only expands the `voice.md` one-liner for discoverability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57dfe497622e509bcb1b542320154ff239defdf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->