### PR TITLE
docs(voice): document canonical feature & product names

### DIFF
--- a/.agents/voice.md
+++ b/.agents/voice.md
@@ -33,8 +33,8 @@ Keep these lists current: when a name changes or a new one ships, update the rel
 
 - Cypress App
 - Cypress Cloud
-- UI Coverage — premium add-on
-- Cypress Accessibility — premium add-on
+- UI Coverage
+- Cypress Accessibility
 
 ### Feature categories
 

--- a/.agents/voice.md
+++ b/.agents/voice.md
@@ -25,8 +25,12 @@ description: Fetch when writing user-facing copy — UI strings, error messages,
 ## Headings
 
 - Headings pull people in; they don't label a shelf. Bias toward action- or outcome-oriented phrasing ("Catch failures before they ship") over dry category labels ("Workflows and integrations"). Category labels read as inert; action-oriented headings tell the reader why to keep reading.
+- Make the verb do work. A heading's verb is its most prominent word — don't spend it on a generic opener like "Get", "Use", or "Discover" that could front any heading. Reach for the verb that names the specific action or payoff: "Ground your agent's responses in official docs" over "Get accurate answers from your agent".
 
 ## Leading with value
 
 - **Lead with the benefit, not the mechanism.** Open with the outcome the reader gets, or the problem it removes — then name the feature that delivers it. The reader decides whether to care based on the "why"; the "what" earns its place once they do. Keep the mechanism in the second clause or the link-out, never the lead. ("Spend less time fixing accessibility violations by hand" before "Cloud MCP exposes accessibility report data.")
 - **Stay in active voice, addressed to the reader.** The reader — or something working on their behalf — is the subject doing or receiving the benefit: "your AI agent ranks what matters", not "violations are ranked". Passive constructions bury who acts and drain the sentence of momentum.
+- **Open the sentence on the verb.** Lead body copy with the action the reader takes — don't start with the feature name or an "X is a…" definition that strands the benefit behind the mechanism. "Ask your coding agent any Cypress question and trust the answer" beats "`cypress-docs` is a new skill that…". Each sentence should earn its momentum from the first word:
+  > Wind back the clock to any point in an application's execution and see exactly what it was doing during the point of failure. Inspect the DOM, network events, and console logs of your application from your tests exactly as they ran in CI.
+  > Review videos, screenshots, and logs for every spec file from any CI test run.

--- a/.agents/voice.md
+++ b/.agents/voice.md
@@ -27,7 +27,7 @@ description: Fetch when writing user-facing copy — UI strings, error messages,
 
 Cypress feature and product names are proper nouns. Capitalize them exactly as listed below — never lowercase them in body copy, even in the middle of a sentence ("…with Smart Orchestration", not "…with smart orchestration"). Sentence case applies to ordinary words in headings and UI strings (see [Capitalization](#capitalization)); it does **not** demote a proper-noun feature name.
 
-Source of truth is the [cypress.io pricing page](https://www.cypress.io/pricing) (`src/components/pages/pricing/**` in the cypress.io repo). When a name changes there or a name is added, update the relevant list below in the same change — keep these living, not a snapshot.
+Source of truth is the cypress.io product navigation (`src/layouts/Header/content/product.yml`) for products and feature categories, and the [pricing page](https://www.cypress.io/pricing) (`src/components/pages/pricing/**`) for individual features. When a name changes there or a name is added, update the relevant list below in the same change — keep these living, not a snapshot.
 
 ### Products
 
@@ -35,29 +35,25 @@ Things customers buy, sign into, or install:
 
 - Cypress App
 - Cypress Cloud
-- Cypress Accessibility — premium add-on
 - UI Coverage — premium add-on
+- Cypress Accessibility — premium add-on
 
 ### Feature categories
 
-The capability groupings the pricing page organizes features under:
+The capability groupings within each product:
 
-- Visual Reviews
-- Smart Orchestration
-- Analytics & Insights
-- Workflow Integrations
-- Test Generation
-- Application Quality
+- **Cypress App:** Browser Testing, Visual Debugging, Test Generation, Flake Resistance
+- **Cypress Cloud:** Visual Reviews, Smart Orchestration, Analytics & Insights, Workflow Integrations
 
 ### Features
 
 Individual capabilities, grouped under their category:
 
-- **Visual Reviews:** Test Replay, Branch Review, AI Summaries, Test Artifacts
-- **Smart Orchestration:** Parallelization, Load Balancing, Manual Cancellation, Auto Cancellation, Spec Prioritization
-- **Analytics & Insights:** Test History, Project Analytics, Flake Detection, Flaky Test Analytics, Enterprise Reporting, Data Extract API
-- **Workflow Integrations:** Status Checks, PR Comments, Team Notifications, Cloud MCP, Jira Integration
-- **Test Generation:** Cypress Studio, Studio AI
+- **Test Generation** (Cypress App): Cypress Studio, Studio AI
+- **Visual Reviews** (Cypress Cloud): Test Replay, Branch Review, AI Summaries, Test Artifacts
+- **Smart Orchestration** (Cypress Cloud): Parallelization, Load Balancing, Manual Cancellation, Auto Cancellation, Spec Prioritization
+- **Analytics & Insights** (Cypress Cloud): Test History, Project Analytics, Flake Detection, Flaky Test Analytics, Enterprise Reporting, Data Extract API
+- **Workflow Integrations** (Cypress Cloud): Status Checks, PR Comments, Team Notifications, Cloud MCP, Jira Integration
 
 ### Plan tiers
 

--- a/.agents/voice.md
+++ b/.agents/voice.md
@@ -31,8 +31,6 @@ Keep these lists current: when a name changes or a new one ships, update the rel
 
 ### Products
 
-Things customers buy, sign into, or install:
-
 - Cypress App
 - Cypress Cloud
 - UI Coverage — premium add-on
@@ -40,14 +38,10 @@ Things customers buy, sign into, or install:
 
 ### Feature categories
 
-The capability groupings within each product:
-
 - **Cypress App:** Browser Testing, Visual Debugging, Test Generation, Flake Resistance
 - **Cypress Cloud:** Visual Reviews, Smart Orchestration, Analytics & Insights, Workflow Integrations
 
 ### Features
-
-Individual capabilities, grouped under their category:
 
 - **Test Generation** (Cypress App): Cypress Studio, Studio AI
 - **Visual Reviews** (Cypress Cloud): Test Replay, Branch Review, AI Summaries, Test Artifacts

--- a/.agents/voice.md
+++ b/.agents/voice.md
@@ -43,7 +43,9 @@ Keep these lists current: when a name changes or a new one ships, update the rel
 
 ### Features
 
+- **Visual Debugging** (Cypress App): Time Travel, Live Reload, Native Browser Inspection, Screenshots & Videos, Embedded Cloud Workflows
 - **Test Generation** (Cypress App): Cypress Studio, Studio AI
+- **Flake Resistance** (Cypress App): Automatic Waiting, Test Retries, Test Isolation, Flake Detection, Consistent Results
 - **Visual Reviews** (Cypress Cloud): Test Replay, Branch Review, AI Summaries, Test Artifacts
 - **Smart Orchestration** (Cypress Cloud): Parallelization, Load Balancing, Manual Cancellation, Auto Cancellation, Spec Prioritization
 - **Analytics & Insights** (Cypress Cloud): Test History, Project Analytics, Flake Detection, Flaky Test Analytics, Enterprise Reporting, Data Extract API

--- a/.agents/voice.md
+++ b/.agents/voice.md
@@ -62,7 +62,7 @@ Keep these lists current: when a name changes or a new one ships, update the rel
 
 - **`cy.prompt`** is a code identifier — keep it verbatim and lowercase, never "Cy.prompt" or "Cy.Prompt" (see [Capitalization](#capitalization) on code identifiers).
 - Integration partner names keep their own branding: **GitHub**, **GitLab**, **Bitbucket**, **Slack**, **MS Teams**, **Jira**, **Okta**, **Azure AD**.
-- **SSO** and **CI / CD** are written in caps, with spaces around the slash in CI / CD.
+- **SSO** and **CI/CD** are written in caps.
 
 ## Headings
 

--- a/.agents/voice.md
+++ b/.agents/voice.md
@@ -37,7 +37,6 @@ Things customers buy, sign into, or install:
 - Cypress Cloud
 - Cypress Accessibility — premium add-on
 - UI Coverage — premium add-on
-- Cypress Studio
 
 ### Feature categories
 
@@ -58,7 +57,7 @@ Individual capabilities, grouped under their category:
 - **Smart Orchestration:** Parallelization, Load Balancing, Manual Cancellation, Auto Cancellation, Spec Prioritization
 - **Analytics & Insights:** Test History, Project Analytics, Flake Detection, Flaky Test Analytics, Enterprise Reporting, Data Extract API
 - **Workflow Integrations:** Status Checks, PR Comments, Team Notifications, Cloud MCP, Jira Integration
-- **Test Generation:** Studio AI
+- **Test Generation:** Cypress Studio, Studio AI
 
 ### Plan tiers
 

--- a/.agents/voice.md
+++ b/.agents/voice.md
@@ -27,7 +27,7 @@ description: Fetch when writing user-facing copy — UI strings, error messages,
 
 Cypress feature and product names are proper nouns. Capitalize them exactly as listed below — never lowercase them in body copy, even in the middle of a sentence ("…with Smart Orchestration", not "…with smart orchestration"). Sentence case applies to ordinary words in headings and UI strings (see [Capitalization](#capitalization)); it does **not** demote a proper-noun feature name.
 
-Source of truth is the cypress.io product navigation (`src/layouts/Header/content/product.yml`) for products and feature categories, and the [pricing page](https://www.cypress.io/pricing) (`src/components/pages/pricing/**`) for individual features. When a name changes there or a name is added, update the relevant list below in the same change — keep these living, not a snapshot.
+Keep these lists current: when a name changes or a new one ships, update the relevant list in the same change — they're living, not a snapshot.
 
 ### Products
 

--- a/.agents/voice.md
+++ b/.agents/voice.md
@@ -27,40 +27,47 @@ description: Fetch when writing user-facing copy — UI strings, error messages,
 
 Cypress feature and product names are proper nouns. Capitalize them exactly as listed below — never lowercase them in body copy, even in the middle of a sentence ("…with Smart Orchestration", not "…with smart orchestration"). Sentence case applies to ordinary words in headings and UI strings (see [Capitalization](#capitalization)); it does **not** demote a proper-noun feature name.
 
-Source of truth is the [cypress.io pricing page](https://www.cypress.io/pricing) (`src/components/pages/pricing/**` in the cypress.io repo). When a name changes there or a feature is added, update this table in the same change — keep it living, not a snapshot.
+Source of truth is the [cypress.io pricing page](https://www.cypress.io/pricing) (`src/components/pages/pricing/**` in the cypress.io repo). When a name changes there or a name is added, update the relevant list below in the same change — keep these living, not a snapshot.
 
-| Name                                   | Type                       |
-| -------------------------------------- | -------------------------- |
-| Cypress App                            | Product                    |
-| Cypress Cloud                          | Product                    |
-| Cypress Accessibility                  | Product (premium add-on)   |
-| UI Coverage                            | Product (premium add-on)   |
-| Cypress Studio                         | Product                    |
-| Test Replay                            | Feature                    |
-| Branch Review                          | Feature                    |
-| AI Summaries                           | Feature                    |
-| Test Artifacts                         | Feature                    |
-| Smart Orchestration                    | Feature (capability suite) |
-| Parallelization                        | Feature                    |
-| Load Balancing                         | Feature                    |
-| Manual Cancellation                    | Feature                    |
-| Auto Cancellation                      | Feature                    |
-| Spec Prioritization                    | Feature                    |
-| Test History                           | Feature                    |
-| Project Analytics                      | Feature                    |
-| Flake Detection                        | Feature                    |
-| Flaky Test Analytics                   | Feature                    |
-| Enterprise Reporting                   | Feature                    |
-| Data Extract API                       | Feature                    |
-| Status Checks                          | Feature                    |
-| PR Comments                            | Feature                    |
-| Team Notifications                     | Feature                    |
-| Cloud MCP                              | Feature                    |
-| Jira Integration                       | Feature                    |
-| Studio AI                              | Feature                    |
-| Starter / Team / Business / Enterprise | Plan tiers                 |
+### Products
 
-Notes:
+Things customers buy, sign into, or install:
+
+- Cypress App
+- Cypress Cloud
+- Cypress Accessibility — premium add-on
+- UI Coverage — premium add-on
+- Cypress Studio
+
+### Feature categories
+
+The capability groupings the pricing page organizes features under:
+
+- Visual Reviews
+- Smart Orchestration
+- Analytics & Insights
+- Workflow Integrations
+- Test Generation
+- Application Quality
+
+### Features
+
+Individual capabilities, grouped under their category:
+
+- **Visual Reviews:** Test Replay, Branch Review, AI Summaries, Test Artifacts
+- **Smart Orchestration:** Parallelization, Load Balancing, Manual Cancellation, Auto Cancellation, Spec Prioritization
+- **Analytics & Insights:** Test History, Project Analytics, Flake Detection, Flaky Test Analytics, Enterprise Reporting, Data Extract API
+- **Workflow Integrations:** Status Checks, PR Comments, Team Notifications, Cloud MCP, Jira Integration
+- **Test Generation:** Studio AI
+
+### Plan tiers
+
+- Starter
+- Team
+- Business
+- Enterprise
+
+### Notes
 
 - **`cy.prompt`** is a code identifier — keep it verbatim and lowercase, never "Cy.prompt" or "Cy.Prompt" (see [Capitalization](#capitalization) on code identifiers).
 - Integration partner names keep their own branding: **GitHub**, **GitLab**, **Bitbucket**, **Slack**, **MS Teams**, **Jira**, **Okta**, **Azure AD**.

--- a/.agents/voice.md
+++ b/.agents/voice.md
@@ -60,7 +60,7 @@ Keep these lists current: when a name changes or a new one ships, update the rel
 
 - **`cy.prompt`** is a code identifier — keep it verbatim and lowercase, never "Cy.prompt" or "Cy.Prompt" (see [Capitalization](#capitalization) on code identifiers).
 - Integration partner names keep their own branding: **GitHub**, **GitLab**, **Bitbucket**, **Slack**, **MS Teams**, **Jira**, **Okta**, **Azure AD**.
-- **SSO** and **CI / CD** are written as the pricing page renders them.
+- **SSO** and **CI / CD** are written in caps, with spaces around the slash in CI / CD.
 
 ## Headings
 

--- a/.agents/voice.md
+++ b/.agents/voice.md
@@ -21,6 +21,50 @@ description: Fetch when writing user-facing copy — UI strings, error messages,
 
 - Sentence case for buttons, headings, menu items, page titles. Not Title Case.
 - Code identifiers stay verbatim — never rewrap or recase them.
+- Feature and product names are proper nouns — see [Feature & product names](#feature--product-names). They keep their exact casing even mid-sentence in sentence-case copy.
+
+## Feature & product names
+
+Cypress feature and product names are proper nouns. Capitalize them exactly as listed below — never lowercase them in body copy, even in the middle of a sentence ("…with Smart Orchestration", not "…with smart orchestration"). Sentence case applies to ordinary words in headings and UI strings (see [Capitalization](#capitalization)); it does **not** demote a proper-noun feature name.
+
+Source of truth is the [cypress.io pricing page](https://www.cypress.io/pricing) (`src/components/pages/pricing/**` in the cypress.io repo). When a name changes there or a feature is added, update this table in the same change — keep it living, not a snapshot.
+
+| Name                                   | Type                       |
+| -------------------------------------- | -------------------------- |
+| Cypress App                            | Product                    |
+| Cypress Cloud                          | Product                    |
+| Cypress Accessibility                  | Product (premium add-on)   |
+| UI Coverage                            | Product (premium add-on)   |
+| Cypress Studio                         | Product                    |
+| Test Replay                            | Feature                    |
+| Branch Review                          | Feature                    |
+| AI Summaries                           | Feature                    |
+| Test Artifacts                         | Feature                    |
+| Smart Orchestration                    | Feature (capability suite) |
+| Parallelization                        | Feature                    |
+| Load Balancing                         | Feature                    |
+| Manual Cancellation                    | Feature                    |
+| Auto Cancellation                      | Feature                    |
+| Spec Prioritization                    | Feature                    |
+| Test History                           | Feature                    |
+| Project Analytics                      | Feature                    |
+| Flake Detection                        | Feature                    |
+| Flaky Test Analytics                   | Feature                    |
+| Enterprise Reporting                   | Feature                    |
+| Data Extract API                       | Feature                    |
+| Status Checks                          | Feature                    |
+| PR Comments                            | Feature                    |
+| Team Notifications                     | Feature                    |
+| Cloud MCP                              | Feature                    |
+| Jira Integration                       | Feature                    |
+| Studio AI                              | Feature                    |
+| Starter / Team / Business / Enterprise | Plan tiers                 |
+
+Notes:
+
+- **`cy.prompt`** is a code identifier — keep it verbatim and lowercase, never "Cy.prompt" or "Cy.Prompt" (see [Capitalization](#capitalization) on code identifiers).
+- Integration partner names keep their own branding: **GitHub**, **GitLab**, **Bitbucket**, **Slack**, **MS Teams**, **Jira**, **Okta**, **Azure AD**.
+- **SSO** and **CI / CD** are written as the pricing page renders them.
 
 ## Headings
 


### PR DESCRIPTION
## What & why

Copy reviews keep slipping on feature-name casing. On cypress.io [#2514](https://github.com/cypress-io/cypress.io/pull/2514) a comparison-page FAQ shipped "Smart orchestration" lowercase — it's a feature name, so it should be "Smart Orchestration". The reviewer asked us to encode the rule: *"Please review and update the voice guidelines if this is not clear."*

This adds a **Feature & product names** section to `voice.md` so the copy-review workflow (which consumes `design.cypress.io/agents/voice.md`) can flag mis-cased usage proactively instead of catching it per-PR.

## How

- New section lists each Cypress feature/product as a proper noun with its exact capitalization, pulled from the cypress.io pricing page (`src/components/pages/pricing/**`) as the source of truth.
- A one-line note in **Capitalization** cross-links it, clarifying that sentence case does not demote a proper-noun feature name.
- Kept as a living Markdown table with a "update it when the pricing page changes" instruction, plus notes covering the `cy.prompt` code-identifier exception, integration partner branding, and SSO / CI / CD rendering.

## Where to focus review

- Are the names and casings correct against the current pricing page? I used the pricing page verbatim — note "Flaky Test Management" (from the task framing) isn't a pricing-page name; the page uses **Flake Detection** and **Flaky Test Analytics**, so those are what's listed.
- Is the table the right grain — too many rows, or missing any name that recurs in body copy?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent voice guidelines; no runtime, auth, or data paths affected.
> 
> **Overview**
> **`voice.md` now encodes canonical Cypress product and feature capitalization** so copy review and agents can catch mis-cased names (e.g. "Smart Orchestration" in body copy) instead of fixing them PR by PR.
> 
> The **Capitalization** bullet now points at a new **Product and feature names** section. That section states feature names stay proper nouns in sentence-case UI, requires keeping the lists current when names ship or change, and adds structured inventories: **Products**, **Feature categories**, nested **Features** under App/Cloud groupings, **Plan tiers**, and a consolidated **Naming rules** block (including `cy.prompt` as a lowercase identifier, partner branding, and **SSO** / **CI/CD**).
> 
> Minor edits elsewhere: the inverted-pyramid link is wrapped in angle brackets for Markdown, and scattered naming bullets are folded into the new structure rather than repeated inline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4061e8786c955e1d3f69d2e03c3af5f03f67e76f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->