### PR TITLE
fix(release): migrate set-version.mjs to Yarn Berry commands

### DIFF
--- a/scripts/set-version.mjs
+++ b/scripts/set-version.mjs
@@ -2,73 +2,91 @@ import { execa } from 'execa'
 import { promises as fs } from 'fs'
 import { join } from 'path'
 import * as url from 'url'
+
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
+const repoRoot = join(__dirname, '..')
 
-async function getVersionNumber(dep) {
-  // get dependency workspace location from yarn
-  const { stdout } = await execa('yarn', ['info', dep, '--json'])
-
-  // remove first and last line from stdout
-  const pkg = JSON.parse(stdout)
-  return pkg.data.version
+/**
+ * Resolve the latest published version of an external (non-workspace)
+ * dependency from the npm registry.
+ *
+ * Yarn Berry split the legacy `yarn info <pkg>` (Yarn 1) — which queried the
+ * npm registry — into two commands:
+ *   - `yarn info <pkg>`     → now queries the local workspace, not npm.
+ *   - `yarn npm info <pkg>` → registry lookup.
+ *
+ * With `--json`, Berry returns a single JSON object whose `version` field is
+ * the latest published version, which is what we want here.
+ */
+async function getNpmRegistryVersion(dep) {
+  const { stdout } = await execa('yarn', ['npm', 'info', dep, '--json'])
+  const info = JSON.parse(stdout)
+  return info.version
 }
 
 async function run() {
-  // get workspaces packages from yarn
-  const { stdout } = await execa('yarn', ['workspaces', 'info'])
-  // remove first and last line from stdout
-  const packages = JSON.parse(stdout.split('\n').slice(1, -1).join(''))
-  const versions = await Object.entries(packages).reduce(
-    async (acc, [name, { location }]) => {
-      acc = await acc
-      // get package.json from each package
-      const pkg = JSON.parse(
-        await fs.readFile(join(__dirname, '..', location, 'package.json')),
-      )
-      acc[name] = pkg.version
-      return acc
-    },
-    {},
-  )
+  // Yarn Berry replacement for Yarn 1's `yarn workspaces info`:
+  //   `yarn workspaces list --json` emits newline-delimited JSON, one
+  //   workspace per line as `{"location": "<rel-path>", "name": "<pkg>"}`.
+  //   The list includes the repo root (location `.`); we keep it in the
+  //   `versions` map for completeness but skip it when rewriting `*` deps
+  //   below because the root's own dependencies aren't workspace-internal
+  //   `*` references.
+  const { stdout } = await execa('yarn', ['workspaces', 'list', '--json'])
+  const workspaces = stdout
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
 
-  Object.values(packages).forEach(async ({ location }) => {
-    // set each dependency version that has a * to the version of the package
-    // extracted above
+  // Build a name → version map by reading each workspace's package.json.
+  const versions = {}
+  for (const ws of workspaces) {
     const pkg = JSON.parse(
-      await fs.readFile(join(__dirname, '..', location, 'package.json')),
+      await fs.readFile(join(repoRoot, ws.location, 'package.json')),
     )
-    if (pkg.dependencies) {
+    versions[ws.name] = pkg.version
+  }
+
+  // For every workspace, replace `*` versions in `dependencies` with a real
+  // version: from the `versions` map for workspace-internal deps, from the
+  // npm registry for external deps. Skip the root workspace (`location: '.'`).
+  await Promise.all(
+    workspaces.map(async (ws) => {
+      if (ws.location === '.') return
+
+      const pkgPath = join(repoRoot, ws.location, 'package.json')
+      const pkg = JSON.parse(await fs.readFile(pkgPath))
+      if (!pkg.dependencies) return
+
       const depsUpdated = []
       await Promise.all(
         Object.entries(pkg.dependencies).map(async ([dep, version]) => {
-          if (version === '*') {
-            if (versions[dep]) {
-              pkg.dependencies[dep] = `^${versions[dep]}`
-            } else {
-              const version = await getVersionNumber(dep)
-              pkg.dependencies[dep] = `^${version}`
-            }
-            depsUpdated.push(dep)
+          if (version !== '*') return
+          if (versions[dep]) {
+            pkg.dependencies[dep] = `^${versions[dep]}`
+          } else {
+            const v = await getNpmRegistryVersion(dep)
+            pkg.dependencies[dep] = `^${v}`
           }
+          depsUpdated.push(dep)
         }),
       )
 
       if (depsUpdated.length === 0) return
-      // write package.json to file
-      await fs.writeFile(
-        `${location}/package.json`,
-        JSON.stringify(pkg, null, 2),
-      )
+
+      await fs.writeFile(pkgPath, JSON.stringify(pkg, null, 2))
 
       console.log()
-      console.log(location.replace(/^components\//, ''))
+      console.log(ws.location.replace(/^components\//, ''))
       console.log(
         depsUpdated.reduce((acc, dep) => {
-          acc[dep] = pkg?.dependencies[dep]
+          acc[dep] = pkg.dependencies[dep]
           return acc
         }, {}),
       )
-    }
-  })
+    }),
+  )
 }
+
 run()


### PR DESCRIPTION
## Summary

Fixes the `Release` workflow on `main`, which has been failing since the Yarn 1 → Berry upgrade and **blocked publishing the new RunResults component** (#676 merged successfully, but the `changesets/action`-triggered publish step exploded before reaching npm).

## What broke

The Release job in [run #27012982893](https://github.com/cypress-io/cypress-design/actions/runs/27012982893/job/79722266232) failed with:

```
Command failed with exit code 1: yarn workspaces info
Unknown Syntax Error: Command not found; did you mean one of:
  0. yarn workspaces list ...
  1. yarn workspaces focus ...
  2. yarn workspaces foreach ...
```

`scripts/set-version.mjs` — the helper that rewrites workspace `*` versions to real published versions right before `changesets/action` runs `yarn changeset publish` — was written for **Yarn 1**.

## Root cause

[PR #659 "Migrate docs from VitePress to Astro" (2026-05-06)](https://github.com/cypress-io/cypress-design/pull/659) included this change to `package.json`:

```diff
-  "packageManager": "yarn@1.22.22"
+  "packageManager": "yarn@4.9.1"
```

Two of the script's commands were silently removed/repurposed in Berry:

| Yarn 1 (script used) | Berry (current Yarn) |
|---|---|
| `yarn workspaces info` (single JSON map) | Removed. Replacement: `yarn workspaces list --json` (NDJSON, one workspace per line). |
| `yarn info <pkg> --json` (npm registry lookup) | Now queries the local workspace, **not** npm. Replacement: `yarn npm info <pkg> --json`. |

The script wasn't updated alongside the `packageManager` bump in #659, so the next release attempt was destined to fail. It only surfaced now because **no non-docs PR merged between #659 and #676**. The docs-only PRs that landed in the meantime never invoked `set-version.mjs` (`changesets/action` only runs the publish chain when there are pending changesets to consume).

So #676 (RunResults) is the canary that tripped this. The RunResults work itself is fine and merged; it's just sitting unpublished on `main` because the release pipeline broke.

## What this PR does

Rewrites `scripts/set-version.mjs` to use the Berry-compatible commands:

- `yarn workspaces info` → `yarn workspaces list --json` (parse NDJSON line-by-line)
- `yarn info <pkg> --json` → `yarn npm info <pkg> --json` (extracted into a `getNpmRegistryVersion` helper with a comment explaining the split)

Two long-standing bugs cleaned up in the same pass while I was in the file:

- **Unified absolute paths** for both reads and writes. The original mixed `join(__dirname, '..', loc, 'package.json')` for reads with `${loc}/package.json` for writes, silently relying on CWD being the repo root.
- **Skip the root workspace** (`location: '.'`) when rewriting `*` deps. `yarn workspaces list --json` includes the root; its dependencies aren't workspace-internal `*` refs and trying to rewrite them produced misleading console output.

## Verified locally

Ran `node scripts/set-version.mjs` on this branch — resolved all workspace-internal and external `*` deps across all ~40 workspaces, including RunResults' three new packages. Sample console output:

```
RunResults/vue
{
  '@cypress-design/constants-runresults': '^0.0.0',
  '@cypress-design/vue-icon': '^1.40.0',
  '@cypress-design/vue-statusicon': '^1.0.0',
  '@cypress-design/vue-tooltip': '^2.1.0'
}
```

(`^0.0.0` for `constants-runresults` is correct — the real version comes from `changesets/action` bumping `0.0.0` → `1.0.0` via the `major` changeset before this script runs in CI.)

## Test plan

- [ ] Merge this. The next `Release` workflow run on `main` should get past the `set-version.mjs` step and let `changesets/action` open its "version packages" PR, which on merge will publish:
  - `@cypress-design/constants-runresults@1.0.0`
  - `@cypress-design/react-runresults@1.0.0`
  - `@cypress-design/vue-runresults@1.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only tooling with no runtime app, auth, or data-path changes; risk is limited to whether publish/version pinning behaves correctly in CI.
> 
> **Overview**
> Updates **`scripts/set-version.mjs`** so the release step that pins workspace `*` dependencies works under **Yarn Berry** instead of Yarn 1.
> 
> **Registry and workspace discovery:** External packages now resolve via **`yarn npm info`** (renamed helper **`getNpmRegistryVersion`** with inline docs on why Berry dropped the old **`yarn info`** behavior). Workspace enumeration uses **`yarn workspaces list --json`**, parsing **NDJSON** lines into a workspace list instead of the removed **`yarn workspaces info`** JSON blob.
> 
> **Behavior and reliability fixes:** Reads and writes both go through **`repoRoot`**-based paths (writes no longer use cwd-relative **`${location}/package.json`**). The root workspace (**`location: '.'`**) is skipped when rewriting `*` deps. The per-package update loop is **`await Promise.all`** over workspaces instead of **`forEach` + async**, so the script finishes before **`changesets/action`** publish runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb118ced7cefd4b5bd3a44df578b6d56c9a8c8be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->