### PR TITLE
docs(agents): make agent-doc links absolute and publish llms.txt

### DIFF
--- a/.agents/accessibility.md
+++ b/.agents/accessibility.md
@@ -5,7 +5,7 @@ description: Accessibility principles and considerations. Fetch when designing i
 
 # Accessibility
 
-When and how to invest in accessibility, plus the patterns that come up most often. The mechanical checks live in [review-checklist.md](./review-checklist.md).
+When and how to invest in accessibility, plus the patterns that come up most often. The mechanical checks live in [review-checklist.md](https://design.cypress.io/agents/review-checklist.md).
 
 ## When to invest
 
@@ -29,7 +29,7 @@ Accessibility is a content concern, not only a design one. These rules apply whe
 
 **Don't rely on visuals alone.** If a reader can't see colors, images, or video, the core message must still land in the text. Provide alt text for informative images and mark decorative ones as decorative. Keep text and key UI at sufficient contrast for low-vision and color-blind readers.
 
-**Use descriptive link text.** A link must make sense on its own — "Read the Test Replay setup guide", never standalone "click here" or "learn more". (Errors and warnings share this rule; see [errors.md](./errors.md).)
+**Use descriptive link text.** A link must make sense on its own — "Read the Test Replay setup guide", never standalone "click here" or "learn more". (Errors and warnings share this rule; see [errors.md](https://design.cypress.io/agents/errors.md).)
 
 **"Disabled" and "disability" are the correct words — don't tiptoe around them.** This language moves quickly, and we'll get corrected sometimes; stay open to it.
 
@@ -42,6 +42,6 @@ When in doubt, check the [accessibility.com glossary](https://www.accessibility.
 
 ## Related
 
-- [voice.md](./voice.md) — general voice, tone, and mechanics for all copy
-- [colors.md](./colors.md) — Contrast tokens
-- [review-checklist.md](./review-checklist.md) — Mechanical a11y checks before shipping
+- [voice.md](https://design.cypress.io/agents/voice.md) — general voice, tone, and mechanics for all copy
+- [colors.md](https://design.cypress.io/agents/colors.md) — Contrast tokens
+- [review-checklist.md](https://design.cypress.io/agents/review-checklist.md) — Mechanical a11y checks before shipping

--- a/.agents/colors.md
+++ b/.agents/colors.md
@@ -11,7 +11,7 @@ description: Fetch when choosing colors, picking tokens for backgrounds/text/bor
 - **Use semantic tokens, not raw hex values.** Tokens carry intent; hex carries only appearance and breaks the moment the palette evolves.
 - **Color alone can't carry meaning.** Pair color with shape, icon, label, or position — colorblind users, dimmed screens, and bright sunlight all defeat color-only signals.
 
-For the broader thinking on how color fits into visual hierarchy, see [principles/visual-hierarchy.md](./principles/visual-hierarchy.md).
+For the broader thinking on how color fits into visual hierarchy, see [principles/visual-hierarchy.md](https://design.cypress.io/agents/principles/visual-hierarchy.md).
 
 ## Palette
 

--- a/.agents/errors.md
+++ b/.agents/errors.md
@@ -25,7 +25,7 @@ Errors, warnings, deprecations, and other system-to-user messages — wherever t
 
 ## Voice + accessibility
 
-[voice.md](./voice.md) owns the general tone rules — fetch it first. Errors and warnings add stricter overrides on top:
+[voice.md](https://design.cypress.io/agents/voice.md) owns the general tone rules — fetch it first. Errors and warnings add stricter overrides on top:
 
 - No wit. No personality. This is a CI failure at 11pm, not an onboarding tour.
 - Concrete, specific verbs over vague ones. "An issue occurred" is not acceptable; "Cypress couldn't reach the dashboard" is.
@@ -56,7 +56,7 @@ For the pre-write checklist, the full message structure pattern, and five annota
 
 ## Related
 
-- [voice.md](./voice.md) — tone, POV, capitalization that applies to all copy
-- [principles/ux.md](./principles/ux.md) — "Never give people a dead end" and the empty-state rule (the broader UX framing that messages are one application of)
-- [accessibility.md](./accessibility.md) — broader accessibility patterns
-- [review-checklist.md](./review-checklist.md) — mechanical checks before shipping
+- [voice.md](https://design.cypress.io/agents/voice.md) — tone, POV, capitalization that applies to all copy
+- [principles/ux.md](https://design.cypress.io/agents/principles/ux.md) — "Never give people a dead end" and the empty-state rule (the broader UX framing that messages are one application of)
+- [accessibility.md](https://design.cypress.io/agents/accessibility.md) — broader accessibility patterns
+- [review-checklist.md](https://design.cypress.io/agents/review-checklist.md) — mechanical checks before shipping

--- a/.agents/iconography.md
+++ b/.agents/iconography.md
@@ -11,7 +11,7 @@ description: Fetch when creating, modifying, or styling icons. Skip for purely s
 - **Don't add icons to disambiguate things that don't need disambiguating.** Every signal added to the UI competes with the signals that actually matter. More icons rarely means more clarity; it usually means more noise.
 - **Prefer a section title + description over a row of `?` tooltips.** Tooltips everywhere read as cluttered and teach the user that they need to hover to understand. A clear heading and short description teaches more with less ink and survives skimming.
 
-For illustration craft (style, framing, lighting, theme, and guidelines), see [illustrations.md](./illustrations.md). For broader visual hierarchy thinking, see [principles/visual-hierarchy.md](./principles/visual-hierarchy.md).
+For illustration craft (style, framing, lighting, theme, and guidelines), see [illustrations.md](https://design.cypress.io/agents/illustrations.md). For broader visual hierarchy thinking, see [principles/visual-hierarchy.md](https://design.cypress.io/agents/principles/visual-hierarchy.md).
 
 ## Construction
 

--- a/.agents/illustrations.md
+++ b/.agents/illustrations.md
@@ -65,7 +65,7 @@ An editorial watercolor language. Atmospheric, landscape-inspired, restrained �
 
 ### Palette (Cypress brand tokens)
 
-Always map to the design-system tokens, not raw hex. Color tokens are at `https://design.cypress.io/colors.css`; the full design-system token set (colors + spacing + typography) is at `https://design.cypress.io/tokens.css`. Both are documented in [colors.md](./colors.md).
+Always map to the design-system tokens, not raw hex. Color tokens are at `https://design.cypress.io/colors.css`; the full design-system token set (colors + spacing + typography) is at `https://design.cypress.io/tokens.css`. Both are documented in [colors.md](https://design.cypress.io/agents/colors.md).
 
 Base / background:
 
@@ -149,8 +149,8 @@ The result should feel intentional, atmospheric, restrained, and softly tied to 
 
 ## Related
 
-- [iconography.md](./iconography.md) — Icon-specific rules
-- [colors.md](./colors.md) — Exact color tokens referenced in the palette
-- [principles/ai.md](./principles/ai.md) — Using AI for generation
-- [principles/visual-hierarchy.md](./principles/visual-hierarchy.md) — How illustration supports content hierarchy
-- [index.md](./index.md) — Router for the rest of the design-system guidance
+- [iconography.md](https://design.cypress.io/agents/iconography.md) — Icon-specific rules
+- [colors.md](https://design.cypress.io/agents/colors.md) — Exact color tokens referenced in the palette
+- [principles/ai.md](https://design.cypress.io/agents/principles/ai.md) — Using AI for generation
+- [principles/visual-hierarchy.md](https://design.cypress.io/agents/principles/visual-hierarchy.md) — How illustration supports content hierarchy
+- [index.md](https://design.cypress.io/agents/index.md) — Router for the rest of the design-system guidance

--- a/.agents/index.md
+++ b/.agents/index.md
@@ -11,27 +11,27 @@ Fetch only what the task needs. Don't preload all files.
 
 Foundational thinking that frames how we make design and product decisions. Fetch when starting design, product, UX, illustration, or AI-assisted work — the pillar files apply the principles to specific tokens and rules.
 
-- [principles/ai.md](./principles/ai.md) — using AI to build, design, write, or review
-- [principles/ux.md](./principles/ux.md) — UX & design principles (the _what_): designing for users, patterns, naming, empty states, restraint, pricing UX. The business-goal / prioritization / discovery _why_-side lives in product.md
-- [principles/product.md](./principles/product.md) — product principles (the _why/whether_): business goals + prioritization, problem definition & discovery, ownership, shipping to learn (measure before launch, don't bundle, set a review date), and post-launch decide. Fetch when planning, prioritizing, defining success, planning research, or reviewing whether shipped work is measured and followed up
-- [principles/visual-hierarchy.md](./principles/visual-hierarchy.md) — directing the eye with color, icons, spacing, size
-- [principles/feedback.md](./principles/feedback.md) — reviewing work and giving feedback
-- [principles/learning-from-feedback.md](./principles/learning-from-feedback.md) — **fetch on every feedback exchange** (PR review, reply to a comment, Slack thread, Zoom recap) — how to spot the rule hiding in a fix and confirm it with the human before documenting
-- [principles/releases.md](./principles/releases.md) — shipping releases, betas, and previews; naming stages; managing feedback quality
+- [principles/ai.md](https://design.cypress.io/agents/principles/ai.md) — using AI to build, design, write, or review
+- [principles/ux.md](https://design.cypress.io/agents/principles/ux.md) — UX & design principles (the _what_): designing for users, patterns, naming, empty states, restraint, pricing UX. The business-goal / prioritization / discovery _why_-side lives in product.md
+- [principles/product.md](https://design.cypress.io/agents/principles/product.md) — product principles (the _why/whether_): business goals + prioritization, problem definition & discovery, ownership, shipping to learn (measure before launch, don't bundle, set a review date), and post-launch decide. Fetch when planning, prioritizing, defining success, planning research, or reviewing whether shipped work is measured and followed up
+- [principles/visual-hierarchy.md](https://design.cypress.io/agents/principles/visual-hierarchy.md) — directing the eye with color, icons, spacing, size
+- [principles/feedback.md](https://design.cypress.io/agents/principles/feedback.md) — reviewing work and giving feedback
+- [principles/learning-from-feedback.md](https://design.cypress.io/agents/principles/learning-from-feedback.md) — **fetch on every feedback exchange** (PR review, reply to a comment, Slack thread, Zoom recap) — how to spot the rule hiding in a fix and confirm it with the human before documenting
+- [principles/releases.md](https://design.cypress.io/agents/principles/releases.md) — shipping releases, betas, and previews; naming stages; managing feedback quality
 
 ## Design pillars
 
 Several pillars lead with a `## Principles` section that governs the tokens and rules below it (colors, typography, spacing, iconography, illustrations). Others (voice, personas, accessibility) are organized differently — open each file for the structure that fits its content.
 
-- [colors.md](./colors.md) — color tokens, contrast, pairings
-- [typography.md](./typography.md) — font, size, weight, line-height
-- [spacing.md](./spacing.md) — margins, padding, gaps, layout dimensions
-- [iconography.md](./iconography.md) — creating or styling icons
-- [illustrations.md](./illustrations.md) — illustration principles, style, theme, and guidelines
-- [voice.md](./voice.md) — UI copy, errors, empty states, tone, capitalization, product naming, mechanics (numbers, dates, punctuation)
-- [errors.md](./errors.md) — errors, warnings, deprecations, and other system-to-user failure messages; distilled from the cypress-error-messages skill in aihub
-- [personas.md](./personas.md) — who uses Cypress and what they need
-- [accessibility.md](./accessibility.md) — when to invest in a11y and the patterns to follow on the surfaces you ship
+- [colors.md](https://design.cypress.io/agents/colors.md) — color tokens, contrast, pairings
+- [typography.md](https://design.cypress.io/agents/typography.md) — font, size, weight, line-height
+- [spacing.md](https://design.cypress.io/agents/spacing.md) — margins, padding, gaps, layout dimensions
+- [iconography.md](https://design.cypress.io/agents/iconography.md) — creating or styling icons
+- [illustrations.md](https://design.cypress.io/agents/illustrations.md) — illustration principles, style, theme, and guidelines
+- [voice.md](https://design.cypress.io/agents/voice.md) — UI copy, errors, empty states, tone, capitalization, product naming, mechanics (numbers, dates, punctuation)
+- [errors.md](https://design.cypress.io/agents/errors.md) — errors, warnings, deprecations, and other system-to-user failure messages; distilled from the cypress-error-messages skill in aihub
+- [personas.md](https://design.cypress.io/agents/personas.md) — who uses Cypress and what they need
+- [accessibility.md](https://design.cypress.io/agents/accessibility.md) — when to invest in a11y and the patterns to follow on the surfaces you ship
 
 ## Components
 
@@ -49,6 +49,6 @@ Fetch on demand — don't preload all of them:
 
 ## Before marking done
 
-Run [review-checklist.md](./review-checklist.md) against your diff (tokens, spacing, a11y — is the surface built right?).
+Run [review-checklist.md](https://design.cypress.io/agents/review-checklist.md) against your diff (tokens, spacing, a11y — is the surface built right?).
 
-When the work is a product brief, initiative, or design proposal — not just a UI surface — also run [product-review-checklist.md](./product-review-checklist.md) (problem defined, alternatives compared, success metric + measurement, review date, post-launch decision — should we be building it, and will we know if it worked?).
+When the work is a product brief, initiative, or design proposal — not just a UI surface — also run [product-review-checklist.md](https://design.cypress.io/agents/product-review-checklist.md) (problem defined, alternatives compared, success metric + measurement, review date, post-launch decision — should we be building it, and will we know if it worked?).

--- a/.agents/principles/ai.md
+++ b/.agents/principles/ai.md
@@ -47,7 +47,7 @@ description: Principles for using AI tools to build, design, write, or review Cy
 
 **Treat agent instructions as a living artifact.** Whenever you find a gap in how an AI handles something, fix the instructions in the same pass as the work. The only way AI gets better at a job is if the guidance gets patched as the holes appear.
 
-**Encode the problem-first check into the tooling.** "Start from the problem, not the solution" ([product.md](./product.md)) applies to agents too — make the agent ask before generating instead of relying on someone to remember. Whatever the brief is called, if it leads with what to build, surface the missing problem first.
+**Encode the problem-first check into the tooling.** "Start from the problem, not the solution" ([product.md](https://design.cypress.io/agents/principles/product.md)) applies to agents too — make the agent ask before generating instead of relying on someone to remember. Whatever the brief is called, if it leads with what to build, surface the missing problem first.
 
 **Use AI to do the synthesis work, then own the conclusion.** The pattern: AI compresses the research, the human signs off on the position. Never publish or decide on AI synthesis without an explicit human endorsement of the conclusion.
 
@@ -59,6 +59,6 @@ description: Principles for using AI tools to build, design, write, or review Cy
 
 ## Related
 
-- [ux.md](./ux.md) — JTBD that gates AI work, plus business goals and success criteria before designing (see "Business goals + user needs" section)
-- [../voice.md](../voice.md) — Voice rules for all AI-generated copy
-- [../review-checklist.md](../review-checklist.md) — Mechanical gate before shipping
+- [ux.md](https://design.cypress.io/agents/principles/ux.md) — JTBD that gates AI work, plus business goals and success criteria before designing (see "Business goals + user needs" section)
+- [voice.md](https://design.cypress.io/agents/voice.md) — Voice rules for all AI-generated copy
+- [review-checklist.md](https://design.cypress.io/agents/review-checklist.md) — Mechanical gate before shipping

--- a/.agents/principles/feedback.md
+++ b/.agents/principles/feedback.md
@@ -13,7 +13,7 @@ description: Principles for reviewing other people's work and giving design / pr
 
 **Push back when the framing is wrong, even if the deliverable looks fine.** "Looks on-brand" is not the same as "ships value." If the underlying problem isn't being solved, no amount of polish on the proposed solution fixes it.
 
-**Challenge a solution-first brief before you build from it.** A brief that leads with what to build isn't ready to execute — send it back with "what problem, whose job?" Fix the missing why at the brief, while it's cheap: once a deliverable exists, people defend it. (The review side of "Start from the problem" in [product.md](./product.md).)
+**Challenge a solution-first brief before you build from it.** A brief that leads with what to build isn't ready to execute — send it back with "what problem, whose job?" Fix the missing why at the brief, while it's cheap: once a deliverable exists, people defend it. (The review side of "Start from the problem" in [product.md](https://design.cypress.io/agents/principles/product.md).)
 
 **Bring options and trade-offs to a review, not one solution to defend.** Showing up to sell a single predetermined idea narrows the room to "yes or no on this." Bring the problem, a few ways to solve it, and the trade-offs — the review's job is to pressure-test the framing and choose among options, not to ratify the one you're attached to.
 
@@ -27,7 +27,7 @@ description: Principles for reviewing other people's work and giving design / pr
 
 ## Related
 
-- [learning-from-feedback.md](./learning-from-feedback.md) — fetch on every feedback exchange, from any source (teammates, other agents, Copilot, automation); shows how to spot the rule hiding in a fix and confirm it with the human before documenting
-- [../review-checklist.md](../review-checklist.md) — Mechanical checks before shipping
-- [ux.md](./ux.md) — Pushback rooted in goals and outcomes (see "Business goals + user needs" section)
-- [../voice.md](../voice.md) — Voice rules apply to feedback too
+- [learning-from-feedback.md](https://design.cypress.io/agents/principles/learning-from-feedback.md) — fetch on every feedback exchange, from any source (teammates, other agents, Copilot, automation); shows how to spot the rule hiding in a fix and confirm it with the human before documenting
+- [review-checklist.md](https://design.cypress.io/agents/review-checklist.md) — Mechanical checks before shipping
+- [ux.md](https://design.cypress.io/agents/principles/ux.md) — Pushback rooted in goals and outcomes (see "Business goals + user needs" section)
+- [voice.md](https://design.cypress.io/agents/voice.md) — Voice rules apply to feedback too

--- a/.agents/principles/learning-from-feedback.md
+++ b/.agents/principles/learning-from-feedback.md
@@ -25,10 +25,10 @@ The same loop runs when _you_ are the one giving feedback. If you find yourself 
 Before adding anything new, check it against the principles already exposed. Surface mismatches instead of going along quietly.
 
 - **Sounds principled but isn't there.** If something is asserted as a design / UX / product principle but isn't in the principle or pillar files, say so plainly: it's reasonable, but it's a _new_ rule, not an existing one. Don't dress a preference up as an existing principle, and don't invent a principle to justify a take.
-- **Conflicts with an existing principle.** If guidance contradicts a principle that _is_ exposed, name the specific principle and the tension — reasoning before verdict (see [feedback.md](./feedback.md)). The existing principle isn't automatically right; the point is to make the conflict explicit so it's resolved deliberately, not by accident.
+- **Conflicts with an existing principle.** If guidance contradicts a principle that _is_ exposed, name the specific principle and the tension — reasoning before verdict (see [feedback.md](https://design.cypress.io/agents/principles/feedback.md)). The existing principle isn't automatically right; the point is to make the conflict explicit so it's resolved deliberately, not by accident.
 - **Additive refinement.** If a take is consistent but a principle would push it further, offer the refinement as additive — not a correction.
 
-Quote the principle verbatim back to the human in the review or reply itself. The quote is how the human confirms that this rule should be documented — or that the rule the agent _thinks_ it heard is what they actually meant. This is a live, audience-facing confirmation, not a private check. (See **"Apply the principle; don't cite it"** in [feedback.md](./feedback.md) — that rule governs how to _apply_ a settled principle in everyday feedback; the quote here is the moment you're settling a new one.)
+Quote the principle verbatim back to the human in the review or reply itself. The quote is how the human confirms that this rule should be documented — or that the rule the agent _thinks_ it heard is what they actually meant. This is a live, audience-facing confirmation, not a private check. (See **"Apply the principle; don't cite it"** in [feedback.md](https://design.cypress.io/agents/principles/feedback.md) — that rule governs how to _apply_ a settled principle in everyday feedback; the quote here is the moment you're settling a new one.)
 
 ## Adding a new principle
 
@@ -37,12 +37,12 @@ Most feedback maps back to a principle that already exists — promote only genu
 When the feedback expresses a rule that genuinely isn't covered:
 
 1. **Confirm it's new** — not a restatement or refinement of something already here.
-2. **Phrase it in the design system's voice** — a bold imperative one-liner plus a short rationale, matching the existing bullets (e.g. the Pricing section in [ux.md](./ux.md)).
+2. **Phrase it in the design system's voice** — a bold imperative one-liner plus a short rationale, matching the existing bullets (e.g. the Pricing section in [ux.md](https://design.cypress.io/agents/principles/ux.md)).
 3. **Place it** in the right file and section, and get the wording signed off.
 4. **Open a PR against this repo** (`cypress-io/cypress-design`). The PR is the record — there's no separate staging log. Consumer repos read these files from the source, so the principle is live everywhere the moment it merges.
 
 ## Related
 
-- [feedback.md](./feedback.md) — giving and receiving feedback; home of "Apply the principle; don't cite it"
-- [ux.md](./ux.md) — the largest body of principles; the voice and style to match when phrasing new ones
-- [../index.md](../index.md) — the router that points agents at these files
+- [feedback.md](https://design.cypress.io/agents/principles/feedback.md) — giving and receiving feedback; home of "Apply the principle; don't cite it"
+- [ux.md](https://design.cypress.io/agents/principles/ux.md) — the largest body of principles; the voice and style to match when phrasing new ones
+- [index.md](https://design.cypress.io/agents/index.md) — the router that points agents at these files

--- a/.agents/principles/product.md
+++ b/.agents/principles/product.md
@@ -5,7 +5,7 @@ description: Product principles — the why/whether side of the canon, paired wi
 
 # Product principles
 
-How product work gets decided and run — from naming the problem, to shipping, to learning whether it worked. [ux.md](./ux.md) is the _what_: the UX, the interaction, the shape of the solution. This file is the _why_ and _whether_: is this the right problem, is the job worth doing, will we know if it worked, and does the work actually get finished? Product and design decide the why together — that overlap is intentional — so this file holds the why side, to keep work from stalling, shipping with no way to measure it, or getting abandoned at "almost done."
+How product work gets decided and run — from naming the problem, to shipping, to learning whether it worked. [ux.md](https://design.cypress.io/agents/principles/ux.md) is the _what_: the UX, the interaction, the shape of the solution. This file is the _why_ and _whether_: is this the right problem, is the job worth doing, will we know if it worked, and does the work actually get finished? Product and design decide the why together — that overlap is intentional — so this file holds the why side, to keep work from stalling, shipping with no way to measure it, or getting abandoned at "almost done."
 
 **The "why" is shared; the "what" is design's.** The problem the product solves — which jobs it serves, and which it deliberately doesn't — is PM and design's to agree on together, before anyone commits to a solution. From that shared why, design owns the what: the solution and its UX hierarchy. The common failure runs backward — a PM or engineer arrives with a _what_ and a _how_ already picked, then reverse-engineers a _why_ to justify shipping it fast. That's selling a solution, not solving a problem, and it usually means the why was never worked out. Pushing back with "why?" until the problem is defined is everyone's job — PM, engineering, and design alike. Design tends to feel the gap first, because it can't choose the right what without a settled why — but that's not a reason design should have to carry it alone.
 
@@ -15,7 +15,7 @@ How product work gets decided and run — from naming the problem, to shipping, 
 
 **When user need and business goal conflict, surface the conflict — don't hide it.** A checkout flow optimized purely for conversion will frustrate users; one optimized purely for user comfort will leave money on the table. The best designs resolve the tension explicitly. The worst pretend it doesn't exist.
 
-**Rank jobs, not solutions — and score the job from both sides.** Prioritize by the customer job, not the feature you'd build for it; how hard something is to build shouldn't decide which customer needs are worth solving. But how much a job matters to the customer is only one input — it says nothing about how much the business gains from solving it, or how long it'll take us (which depends on the solution we pick). Rank on customer importance and business value together (see "UX lives where business goals meet user needs" in [ux.md](./ux.md)), then weigh against cost to solve — without letting "it's hard" bury a job that matters.
+**Rank jobs, not solutions — and score the job from both sides.** Prioritize by the customer job, not the feature you'd build for it; how hard something is to build shouldn't decide which customer needs are worth solving. But how much a job matters to the customer is only one input — it says nothing about how much the business gains from solving it, or how long it'll take us (which depends on the solution we pick). Rank on customer importance and business value together (see "UX lives where business goals meet user needs" in [ux.md](https://design.cypress.io/agents/principles/ux.md)), then weigh against cost to solve — without letting "it's hard" bury a job that matters.
 
 **Define what success looks like before you design.** Name the business outcome the work moves and how you'll measure it, up front — knowing how it'll be measured changes the design itself. Skip it and you'll ship, then hunt for metrics that flatter the result. A design you can't tie to a measurable payback isn't done, no matter how polished.
 
@@ -29,7 +29,7 @@ How product work gets decided and run — from naming the problem, to shipping, 
 
 **A POC has to prove something that matters — say what before you build it.** "We can build it" isn't a result. Name the hypothesis the POC tests and the decision its outcome drives. Are we proving we can launch a rocket, or that we can get to Mars? If you can't say what a successful POC would teach you, you're not ready to build it.
 
-**Map the opportunity space before you commit engineering.** That any single ask is rarely the best solution is the starting point (see "Build against the outcome" and "One solution rarely solves a big problem" in [ux.md](./ux.md)) — this is the discovery practice that acts on it. Chart the candidate solutions to a problem (an opportunity-solution tree works well) and carry a few into discovery, so the comparison happens before the build, not after. Being handed a fixed feature to execute skips the step where solutions get weighed against each other.
+**Map the opportunity space before you commit engineering.** That any single ask is rarely the best solution is the starting point (see "Build against the outcome" and "One solution rarely solves a big problem" in [ux.md](https://design.cypress.io/agents/principles/ux.md)) — this is the discovery practice that acts on it. Chart the candidate solutions to a problem (an opportunity-solution tree works well) and carry a few into discovery, so the comparison happens before the build, not after. Being handed a fixed feature to execute skips the step where solutions get weighed against each other.
 
 **Tie every solution to a job, and every job to the vision.** A solution should clearly serve a specific job, and that job should clearly advance the product vision. When those links are missing, work still ships but moves nothing that matters — there's no agreed destination for it to serve. Agree on where you're going before debating how to get there; if the team can't agree on the destination, don't start building.
 
@@ -55,7 +55,7 @@ In order, all before launch: define success ("Define what success looks like bef
 
 **Build the measurement before you ship, not after.** The dashboard, query, or session path that captures the metric has to exist before launch. Ship without it and you've given up the ability to know whether it worked — you can't repeat a win or catch a regression.
 
-**Don't bundle changes you want to learn from.** Several changes shipped together can't be told apart — if the number moves, you don't know which change moved it. Ship one variable at a time when the goal is learning. When you must bundle, set the confidence threshold up front so you know when there's enough signal to judge the result. (Distinct from release-slicing in [releases.md](./releases.md), which is about not stripping the value out of a release; this is about attribution.)
+**Don't bundle changes you want to learn from.** Several changes shipped together can't be told apart — if the number moves, you don't know which change moved it. Ship one variable at a time when the goal is learning. When you must bundle, set the confidence threshold up front so you know when there's enough signal to judge the result. (Distinct from release-slicing in [releases.md](https://design.cypress.io/agents/principles/releases.md), which is about not stripping the value out of a release; this is about attribution.)
 
 **Set the review date before you ship.** Put the date the team will look at results on a real calendar — don't rely on someone remembering. The date is the forcing function that turns "we'll see how it does" into an actual decision.
 
@@ -67,8 +67,8 @@ In order, all before launch: define success ("Define what success looks like bef
 
 ## Related
 
-- [ux.md](./ux.md) — the design/what side: designing for users, patterns, naming, empty states, pricing UX, restraint. "UX lives where business goals meet user needs" is the bridge between the two files
-- [feedback.md](./feedback.md) — challenging a solution-first brief before work starts
-- [releases.md](./releases.md) — release stages, betas, slicing a release honestly
-- [../product-review-checklist.md](../product-review-checklist.md) — the before/before-shipping/after checklist that operationalizes these principles
-- [../index.md](../index.md) — the router that points agents at these files
+- [ux.md](https://design.cypress.io/agents/principles/ux.md) — the design/what side: designing for users, patterns, naming, empty states, pricing UX, restraint. "UX lives where business goals meet user needs" is the bridge between the two files
+- [feedback.md](https://design.cypress.io/agents/principles/feedback.md) — challenging a solution-first brief before work starts
+- [releases.md](https://design.cypress.io/agents/principles/releases.md) — release stages, betas, slicing a release honestly
+- [product-review-checklist.md](https://design.cypress.io/agents/product-review-checklist.md) — the before/before-shipping/after checklist that operationalizes these principles
+- [index.md](https://design.cypress.io/agents/index.md) — the router that points agents at these files

--- a/.agents/principles/releases.md
+++ b/.agents/principles/releases.md
@@ -19,7 +19,7 @@ description: Principles for shipping releases, betas, previews, feature flags, a
 
 ## Release titles
 
-**Lead with the benefit, but name the feature when people search for it.** Release titles follow the same benefit-first rule as the rest of the product ([voice.md](../voice.md), "Leading with value") — open on the outcome, not the mechanism. A release index adds a second job: it's a scan-and-navigate surface, and for some launches a search-and-discovery one. A benefit-only title can leave someone scanning the list unsure what actually shipped, and feature or category names aren't always self-explanatory on their own (e.g. "Smart Orchestration").
+**Lead with the benefit, but name the feature when people search for it.** Release titles follow the same benefit-first rule as the rest of the product ([voice.md](https://design.cypress.io/agents/voice.md), "Leading with value") — open on the outcome, not the mechanism. A release index adds a second job: it's a scan-and-navigate surface, and for some launches a search-and-discovery one. A benefit-only title can leave someone scanning the list unsure what actually shipped, and feature or category names aren't always self-explanatory on their own (e.g. "Smart Orchestration").
 
 **When a release introduces a term people come looking for — a product or feature name with recognition or search value, like "Cloud MCP" — put it in the title alongside the benefit.** Keep the benefit-led phrasing, and tag it with the name as a short prefix: `Cloud MCP Beta: Debug failing tests with your AI assistant`, not `Debug failing tests with your AI assistant (beta)`. The value-first phrasing stays; the title also reads clearly to scanners and search.
 
@@ -33,10 +33,10 @@ description: Principles for shipping releases, betas, previews, feature flags, a
 
 ## Deprecation
 
-**"Sunsetting in 30 days" is a rug pull, not a deprecation.** Give customers real lead time, an in-product migration path, and a clear date communicated _in the product itself_ — not just in release notes nobody reads. Deprecation done well preserves trust; deprecation done in a hurry destroys it. The same rule runs in reverse when you make a free capability paid — see [ux.md](./ux.md), "Turning a free capability paid is a rug pull" in the Pricing section.
+**"Sunsetting in 30 days" is a rug pull, not a deprecation.** Give customers real lead time, an in-product migration path, and a clear date communicated _in the product itself_ — not just in release notes nobody reads. Deprecation done well preserves trust; deprecation done in a hurry destroys it. The same rule runs in reverse when you make a free capability paid — see [ux.md](https://design.cypress.io/agents/principles/ux.md), "Turning a free capability paid is a rug pull" in the Pricing section.
 
 ## Related
 
-- [product.md](./product.md) — "Sunk cost doesn't earn the next step" (Business goals & prioritization)
-- [ux.md](./ux.md) — "Turning a free capability paid is a rug pull" in the Pricing section — the free→paid mirror of the deprecation rule above
-- [feedback.md](./feedback.md) — Giving and receiving feedback on what gets shipped
+- [product.md](https://design.cypress.io/agents/principles/product.md) — "Sunk cost doesn't earn the next step" (Business goals & prioritization)
+- [ux.md](https://design.cypress.io/agents/principles/ux.md) — "Turning a free capability paid is a rug pull" in the Pricing section — the free→paid mirror of the deprecation rule above
+- [feedback.md](https://design.cypress.io/agents/principles/feedback.md) — Giving and receiving feedback on what gets shipped

--- a/.agents/principles/ux.md
+++ b/.agents/principles/ux.md
@@ -9,7 +9,7 @@ description: UX & design principles — the "what" side: designing for users, in
 
 **UX lives where business goals meet user needs.** JTBD captures the user side well, but the framework is usually phrased entirely from the user's perspective — which quietly hides the business outcome a design has to drive. Good UX serves both at once. If a flow only serves the user, the business gets nothing measurable; if it only serves the business, users feel manipulated and leave. The work is to find designs where both sides win.
 
-For naming the business goal, prioritizing jobs, defining success, deciding whether the work earns the next step, and problem definition + discovery, see [product.md](./product.md) — the why/whether side of the canon.
+For naming the business goal, prioritizing jobs, defining success, deciding whether the work earns the next step, and problem definition + discovery, see [product.md](https://design.cypress.io/agents/principles/product.md) — the why/whether side of the canon.
 
 ## Designing for users
 
@@ -75,7 +75,7 @@ For naming the business goal, prioritizing jobs, defining success, deciding whet
 
 **Empty states without a signal or CTA look like bugs.** If a section has nothing in it and gives no hint of what to do next, users assume the page is broken. Every empty state needs a one-line explanation ("you haven't connected any integrations yet") and a path forward ("Connect one →").
 
-For errors, warnings, and other system-to-user failure messages, see [`../errors.md`](../errors.md) — the principles there (structure, tone, link conventions, no-blame, transient handling) apply whenever the product talks to the user about something that happened.
+For errors, warnings, and other system-to-user failure messages, see [`../errors.md`](https://design.cypress.io/agents/errors.md) — the principles there (structure, tone, link conventions, no-blame, transient handling) apply whenever the product talks to the user about something that happened.
 
 ## Feature naming & positioning
 
@@ -85,7 +85,7 @@ For errors, warnings, and other system-to-user failure messages, see [`../errors
 
 **Design picks naming candidates. GTM validates.** Designers know the product surface and the user vocabulary; GTM knows how the name will land in trial calls, ads, and sales conversations. Don't finalize a feature name without that loop.
 
-**Feature placement is a statement of belief — and a price signal.** Burying a high-value feature in settings tells everyone — customers, sales, and the rest of the team — that you don't believe it deserves attention, and shipping an enterprise-grade capability as "just config" tells them it isn't worth paying for. If the feature is real, give it real placement; if it protects the customer's business the way a security or audit product does, position and price it that way. If it doesn't deserve real placement, question why you're shipping it at all. (This is about how the _real_ feature ships — a deliberately quiet dev preview is a separate choice; see [releases.md](./releases.md).)
+**Feature placement is a statement of belief — and a price signal.** Burying a high-value feature in settings tells everyone — customers, sales, and the rest of the team — that you don't believe it deserves attention, and shipping an enterprise-grade capability as "just config" tells them it isn't worth paying for. If the feature is real, give it real placement; if it protects the customer's business the way a security or audit product does, position and price it that way. If it doesn't deserve real placement, question why you're shipping it at all. (This is about how the _real_ feature ships — a deliberately quiet dev preview is a separate choice; see [releases.md](https://design.cypress.io/agents/principles/releases.md).)
 
 ## Pricing
 
@@ -99,7 +99,7 @@ For errors, warnings, and other system-to-user failure messages, see [`../errors
 
 **Signal future monetization at first exposure — not after adoption.** If a feature will eventually be paid, restricted to a higher tier, or moved behind an enterprise plan, position it that way from day one — "preview of an enterprise capability," "free during preview, paid in the future," or similar. Letting customers anchor on it as a standard included setting and then changing the model later creates product debt and a rug-pull conversation. The moment to set the expectation is on first exposure, when customers form their mental model — not a year in, when changing it means explaining why we're now charging for something they've used freely.
 
-**Turning a free capability paid is a rug pull unless you give lead time and promise no retroactive charges.** Charging for something customers have used freely is as trust-sensitive as deprecating something they depend on, and gets the same treatment: announce before it lands, give a grace period, and state explicitly that nothing already used will be billed retroactively. Signaling monetization at first exposure (above) sets the expectation; this is the commitment that keeps the GA moment from reading as a bait-and-switch. See [releases.md](./releases.md) — the "Sunsetting in 30 days" rug-pull rule is the same logic from the deprecation side.
+**Turning a free capability paid is a rug pull unless you give lead time and promise no retroactive charges.** Charging for something customers have used freely is as trust-sensitive as deprecating something they depend on, and gets the same treatment: announce before it lands, give a grace period, and state explicitly that nothing already used will be billed retroactively. Signaling monetization at first exposure (above) sets the expectation; this is the commitment that keeps the GA moment from reading as a bait-and-switch. See [releases.md](https://design.cypress.io/agents/principles/releases.md) — the "Sunsetting in 30 days" rug-pull rule is the same logic from the deprecation side.
 
 **Sell the risk people are protecting against, not the feature.** People invest in testing because they have a business to protect — outages, regressions, brand damage. Lead with that. CI minutes and run times are useful supporting evidence, never the headline. Insurance and security companies sell risk for a reason.
 
@@ -111,8 +111,8 @@ For errors, warnings, and other system-to-user failure messages, see [`../errors
 
 ## Related
 
-- [product.md](./product.md) — the _why/whether_ side: business goals + prioritization, problem definition & discovery, and running the work. This file is the _what_
-- [visual-hierarchy.md](./visual-hierarchy.md) — Directing the eye once the JTBD is clear
-- [feedback.md](./feedback.md) — How to push back when framing is wrong
-- [../personas.md](../personas.md) — Who you're designing for
-- [../voice.md](../voice.md) — Copy tone
+- [product.md](https://design.cypress.io/agents/principles/product.md) — the _why/whether_ side: business goals + prioritization, problem definition & discovery, and running the work. This file is the _what_
+- [visual-hierarchy.md](https://design.cypress.io/agents/principles/visual-hierarchy.md) — Directing the eye once the JTBD is clear
+- [feedback.md](https://design.cypress.io/agents/principles/feedback.md) — How to push back when framing is wrong
+- [personas.md](https://design.cypress.io/agents/personas.md) — Who you're designing for
+- [voice.md](https://design.cypress.io/agents/voice.md) — Copy tone

--- a/.agents/principles/visual-hierarchy.md
+++ b/.agents/principles/visual-hierarchy.md
@@ -19,7 +19,7 @@ description: Principles for directing the eye through color, icons, spacing, siz
 
 ## Related
 
-- [../colors.md](../colors.md) — Color tokens and contrast
-- [../typography.md](../typography.md) — Type scale and hierarchy
-- [../spacing.md](../spacing.md) — Spacing as a hierarchy tool
-- [ux.md](./ux.md) — JTBD and the primary job framework
+- [colors.md](https://design.cypress.io/agents/colors.md) — Color tokens and contrast
+- [typography.md](https://design.cypress.io/agents/typography.md) — Type scale and hierarchy
+- [spacing.md](https://design.cypress.io/agents/spacing.md) — Spacing as a hierarchy tool
+- [ux.md](https://design.cypress.io/agents/principles/ux.md) — JTBD and the primary job framework

--- a/.agents/product-review-checklist.md
+++ b/.agents/product-review-checklist.md
@@ -5,9 +5,9 @@ description: Run when reviewing a product brief, initiative, or design proposal 
 
 # Product review checklist
 
-Run before committing engineering to an initiative, before shipping it, and after it ships. If a check doesn't apply, skip it; otherwise it must pass. Each maps to a principle in [principles/ux.md](./principles/ux.md) or [principles/product.md](./principles/product.md).
+Run before committing engineering to an initiative, before shipping it, and after it ships. If a check doesn't apply, skip it; otherwise it must pass. Each maps to a principle in [principles/ux.md](https://design.cypress.io/agents/principles/ux.md) or [principles/product.md](https://design.cypress.io/agents/principles/product.md).
 
-This is the product-rigor companion to [review-checklist.md](./review-checklist.md) (tokens, spacing, a11y). That one asks "is the surface built right?"; this one asks "should we be building it, and will we know if it worked?"
+This is the product-rigor companion to [review-checklist.md](https://design.cypress.io/agents/review-checklist.md) (tokens, spacing, a11y). That one asks "is the surface built right?"; this one asks "should we be building it, and will we know if it worked?"
 
 ## Before starting work
 

--- a/.agents/review-checklist.md
+++ b/.agents/review-checklist.md
@@ -10,17 +10,17 @@ Run through these before you say "done." If a check doesn't apply (e.g. no copy 
 ## Colors
 
 - [ ] No raw hex values (`#abc`, `#aabbcc`) or `rgb(...)` introduced. Grep the diff: `grep -nE '#[0-9a-fA-F]{3,8}\b|rgb\(|rgba\(' <changed files>`. If any match, replace with a `--cy-*` token or Tailwind class.
-- [ ] Text contrast: body text on white uses step `600` or darker; on `gray-1000` uses `300` or lighter. See [colors.md](./colors.md).
+- [ ] Text contrast: body text on white uses step `600` or darker; on `gray-1000` uses `300` or lighter. See [colors.md](https://design.cypress.io/agents/colors.md).
 - [ ] Tertiary hues (Fuchsia / Green / Magenta) only appear in syntax highlighting or chart code paths.
 
 ## Spacing
 
 - [ ] Every new spacing value (margin / padding / gap / width / height) is a multiple of 4. Grep the diff for `[0-9]+px` and confirm.
-- [ ] Tailwind spacing utilities used in preference to inline pixel values. See [spacing.md](./spacing.md).
+- [ ] Tailwind spacing utilities used in preference to inline pixel values. See [spacing.md](https://design.cypress.io/agents/spacing.md).
 
 ## Iconography
 
-- [ ] New SVGs use `strokeWidth="2"`, `stroke="currentColor"`, `fill="none"`, `strokeLinecap="round"`, `strokeLinejoin="round"`. See [iconography.md](./iconography.md).
+- [ ] New SVGs use `strokeWidth="2"`, `stroke="currentColor"`, `fill="none"`, `strokeLinecap="round"`, `strokeLinejoin="round"`. See [iconography.md](https://design.cypress.io/agents/iconography.md).
 
 ## Components
 
@@ -28,8 +28,8 @@ Run through these before you say "done." If a check doesn't apply (e.g. no copy 
 
 ## Voice & content
 
-- [ ] User-facing strings follow [voice.md](./voice.md): sentence case, no "simply / just / easy", verb-first button labels.
-- [ ] Error messages state what happened + what to do next. See [voice.md](./voice.md).
+- [ ] User-facing strings follow [voice.md](https://design.cypress.io/agents/voice.md): sentence case, no "simply / just / easy", verb-first button labels.
+- [ ] Error messages state what happened + what to do next. See [voice.md](https://design.cypress.io/agents/voice.md).
 
 ## Accessibility
 
@@ -43,6 +43,6 @@ Run through these before you say "done." If a check doesn't apply (e.g. no copy 
 
 ## Release
 
-- [ ] If the diff touches a published package (anything under `components/`), include a `.changeset/*.md` file — otherwise the release workflow has nothing to publish. See [implement-component](./skills/implement-component.md) for conventions (bump levels, file placement, examples).
+- [ ] If the diff touches a published package (anything under `components/`), include a `.changeset/*.md` file — otherwise the release workflow has nothing to publish. See [implement-component](https://design.cypress.io/agents/skills/implement-component.md) for conventions (bump levels, file placement, examples).
 
 If a check fails, fix the code, don't relax the rule.

--- a/.agents/spacing.md
+++ b/.agents/spacing.md
@@ -12,7 +12,7 @@ description: Fetch when setting margins, padding, gaps, sizing, or any layout di
 - **Group with proximity. Separate with space.** Elements that belong together should be visually closer than elements that don't. This is the cheapest hierarchy tool available and the most underused.
 - **Vertical rhythm matters.** Consistent vertical spacing between elements creates a sense of order users feel without naming it. Breaking rhythm should serve a purpose — punctuating a section, signaling a different kind of content — not happen by drift.
 
-For the broader thinking on how spacing fits into visual hierarchy, see [principles/visual-hierarchy.md](./principles/visual-hierarchy.md).
+For the broader thinking on how spacing fits into visual hierarchy, see [principles/visual-hierarchy.md](https://design.cypress.io/agents/principles/visual-hierarchy.md).
 
 ## The grid
 

--- a/.agents/typography.md
+++ b/.agents/typography.md
@@ -12,7 +12,7 @@ description: Fetch when setting font family, size, weight, line-height, or lette
 - **Body text has a job; display text has a different job.** Body is for reading at length — optimize for readability and rhythm. Display is for catching attention — optimize for impact. Don't confuse the two.
 - **Line height is invisible padding — compensate for it.** A text block with `padding: 16px` on all sides looks lopsided when the line-height already adds visible vertical space above and below the text. The result reads as more top/bottom padding than side padding. Bias toward smaller top/bottom padding (e.g. side `24px`, top/bottom `16px`) so the perceived spacing balances.
 
-For the broader thinking on how typography fits into visual hierarchy, see [principles/visual-hierarchy.md](./principles/visual-hierarchy.md).
+For the broader thinking on how typography fits into visual hierarchy, see [principles/visual-hierarchy.md](https://design.cypress.io/agents/principles/visual-hierarchy.md).
 
 ## Font families
 
@@ -33,4 +33,4 @@ Never set `font-family` inline — the correct stack is applied by the global co
 - `14px` — secondary/supporting information only (`text-sm`)
 - `12px` — reserve for high info-density scenarios; use sparingly (`text-xs`)
 - Headings: prefer the existing `<h1>`–`<h4>` styles in `docs/`; do not introduce new sizes.
-- Line-height stays on the 4px grid (`leading-5`, `leading-6`, `leading-7` — see [spacing.md](./spacing.md)).
+- Line-height stays on the 4px grid (`leading-5`, `leading-6`, `leading-7` — see [spacing.md](https://design.cypress.io/agents/spacing.md)).

--- a/.agents/voice.md
+++ b/.agents/voice.md
@@ -24,7 +24,7 @@ Lead with reader benefit; the action you want follows from understanding. See [L
 - No hype, no marketing fluff. Avoid "simply", "just", "easy", "powerful", "seamless", "delight".
 - Prefer present tense, active voice.
 - **Match register to stakes.** The voice stays constant; the register tightens as stakes rise. More instructional for tutorials and learning; calm and direct for product changes; serious and precise for security, reliability, and deprecations. Clarity always outranks personality.
-- For errors, warnings, and deprecation messages specifically — stricter rules apply (no exclamation points, no blame, structured what/why/next). See [errors.md](./errors.md).
+- For errors, warnings, and deprecation messages specifically — stricter rules apply (no exclamation points, no blame, structured what/why/next). See [errors.md](https://design.cypress.io/agents/errors.md).
 
 ## Point of view
 
@@ -44,7 +44,7 @@ People skim before they commit. Write so the structure carries the meaning on a 
 ## Confidence and certainty
 
 - **Be direct about what we know; be explicit about uncertainty when it exists.** Never imply a guarantee where there isn't one.
-- **When behavior is probabilistic or evolving, say so.** This matters most for AI-powered features — don't frame AI as autonomous or magical, don't promise correctness without guardrails, and don't imply it replaces human judgment. For the principles behind building with AI, see [principles/ai.md](./principles/ai.md).
+- **When behavior is probabilistic or evolving, say so.** This matters most for AI-powered features — don't frame AI as autonomous or magical, don't promise correctness without guardrails, and don't imply it replaces human judgment. For the principles behind building with AI, see [principles/ai.md](https://design.cypress.io/agents/principles/ai.md).
 
 ## Capitalization
 
@@ -113,7 +113,7 @@ Keep these lists current: when a name changes or a new one ships, update the rel
 
 - **Lead with the benefit, not the mechanism.** Open with the outcome the reader gets, or the problem it removes — then name the feature that delivers it. The reader decides whether to care based on the "why"; the "what" earns its place once they do. Keep the mechanism in the second clause or the link-out, never the lead. ("Spend less time fixing accessibility violations by hand" before "Cloud MCP exposes accessibility report data.")
 - **Stay in active voice, addressed to the reader.** The reader — or something working on their behalf — is the subject doing or receiving the benefit: "your AI agent ranks what matters", not "violations are ranked". Passive constructions bury who acts and drain the sentence of momentum.
-- **In release titles, name the searchable feature alongside the benefit.** A release index is also a scan-and-search surface, so a benefit-only title can hide what shipped. When a launch introduces a term people look for (e.g. "Cloud MCP"), prefix the benefit with it — `Cloud MCP Beta: Debug failing tests with your AI assistant`. See [releases.md](./principles/releases.md), "Release titles".
+- **In release titles, name the searchable feature alongside the benefit.** A release index is also a scan-and-search surface, so a benefit-only title can hide what shipped. When a launch introduces a term people look for (e.g. "Cloud MCP"), prefix the benefit with it — `Cloud MCP Beta: Debug failing tests with your AI assistant`. See [releases.md](https://design.cypress.io/agents/principles/releases.md), "Release titles".
 - **Open the sentence on the verb.** Lead body copy with the action the reader takes — don't start with the feature name or an "X is a…" definition that strands the benefit behind the mechanism. "Ask your coding agent any Cypress question and trust the answer" beats "`cypress-docs` is a new skill that…". Each sentence should earn its momentum from the first word:
   > Wind back the clock to any point in an application's execution and see exactly what it was doing during the point of failure. Inspect the DOM, network events, and console logs of your application from your tests exactly as they ran in CI.
   > Review videos, screenshots, and logs for every spec file from any CI test run.
@@ -122,11 +122,11 @@ Keep these lists current: when a name changes or a new one ships, update the rel
 
 - **Numbers.** Spell out one through nine; use numerals for 10 and above. Always use numerals for metrics, measurements, and performance data.
 - **Dates and time.** Spell out the day of the week and abbreviate the month (Tuesday, Jan 14). Use numerals with am/pm (7am, 7:30pm). Include time zones when scheduling matters.
-- **Punctuation.** Use the serial (Oxford) comma. Use a colon to introduce a list. Use em dashes sparingly. Never use exclamation points in error messages or alerts — see [errors.md](./errors.md).
+- **Punctuation.** Use the serial (Oxford) comma. Use a colon to introduce a list. Use em dashes sparingly. Never use exclamation points in error messages or alerts — see [errors.md](https://design.cypress.io/agents/errors.md).
 
 ## Writing about accessibility and inclusion
 
-When your copy concerns accessibility, disability, or assistive technology — alt text, link text, color reliance, and the language to use (and avoid) when referring to people with disabilities — the content rules live in [accessibility.md](./accessibility.md), "Writing about accessibility and disability". Fetch it before writing that content.
+When your copy concerns accessibility, disability, or assistive technology — alt text, link text, color reliance, and the language to use (and avoid) when referring to people with disabilities — the content rules live in [accessibility.md](https://design.cypress.io/agents/accessibility.md), "Writing about accessibility and disability". Fetch it before writing that content.
 
 ## Before you publish
 
@@ -134,8 +134,8 @@ Confirm the reader can answer: what changed, why Cypress made this choice, wheth
 
 ## Related
 
-- [errors.md](./errors.md) — stricter overrides for errors, warnings, and deprecations
-- [accessibility.md](./accessibility.md) — content accessibility and disability language
-- [principles/ai.md](./principles/ai.md) — building, designing, and writing with AI
-- [principles/ux.md](./principles/ux.md) — where business goals meet user needs
-- [principles/releases.md](./principles/releases.md) — release titles and shipping stages
+- [errors.md](https://design.cypress.io/agents/errors.md) — stricter overrides for errors, warnings, and deprecations
+- [accessibility.md](https://design.cypress.io/agents/accessibility.md) — content accessibility and disability language
+- [principles/ai.md](https://design.cypress.io/agents/principles/ai.md) — building, designing, and writing with AI
+- [principles/ux.md](https://design.cypress.io/agents/principles/ux.md) — where business goals meet user needs
+- [principles/releases.md](https://design.cypress.io/agents/principles/releases.md) — release titles and shipping stages

--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ storybook
 .astro/
 .yarn/install-state.gz
 docs/public/agents/
+docs/public/llms.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ When the work is a product brief, initiative, or design proposal (not just a UI 
 
 When opening a PR, lead the description with the problem and goal (why / what) before the implementation (how) — see [`.github/pull_request_template.md`](.github/pull_request_template.md). Reviewers, human and AI, evaluate against the stated goal; a description that's all _how_ steers them toward syntax nitpicks instead of substance.
 
-Everything under `/.agents/` is also served at `https://design.cypress.io/agents/` for consumer repos to fetch — same files, single source of truth.
+Everything under `/.agents/` is also served at `https://design.cypress.io/agents/` for consumer repos to fetch — same files, single source of truth. Cross-doc links in these files use absolute `https://design.cypress.io/agents/...` URLs (not relative paths) so that agents fetching one doc over HTTP can follow links to the rest — keep new links absolute. `scripts/copy-agents.mjs` also generates `llms.txt` at the domain root listing every served doc, so the whole tree is discoverable from `https://design.cypress.io/llms.txt`.
 
 ## Framing — why the design system exists and how it's structured
 

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -15,4 +15,8 @@ The Cypress design system is the system of:
 
 Use the navigation to browse specific components and guides.
 
+## For AI agents
+
+Agent-readable guidance is served as plain markdown. Start with the index at [https://design.cypress.io/agents/index.md](https://design.cypress.io/agents/index.md) — it links to every principle, pillar, and component doc with absolute URLs. A full listing also lives at [https://design.cypress.io/llms.txt](https://design.cypress.io/llms.txt).
+
 Feedback welcome! Please [open an issue](https://github.com/cypress-io/cypress-design).

--- a/scripts/copy-agents.mjs
+++ b/scripts/copy-agents.mjs
@@ -1,5 +1,12 @@
-import { cpSync, mkdirSync, rmSync, readdirSync, existsSync } from 'fs'
-import { join, dirname } from 'path'
+import {
+  cpSync,
+  mkdirSync,
+  rmSync,
+  readdirSync,
+  existsSync,
+  writeFileSync,
+} from 'fs'
+import { join, dirname, relative, sep } from 'path'
 import { fileURLToPath } from 'url'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
@@ -37,3 +44,27 @@ for (const entry of readdirSync(componentsDir, { withFileTypes: true })) {
     }
   }
 }
+
+// llms.txt — list every served doc as an absolute URL so agents can discover
+// (and fetch tools can unlock) the whole tree from the domain root
+const BASE_URL = 'https://design.cypress.io/agents'
+const docs = readdirSync(dest, { recursive: true, withFileTypes: true })
+  .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+  .map((entry) =>
+    relative(dest, join(entry.parentPath, entry.name)).split(sep).join('/'),
+  )
+  .sort()
+const llmsTxt = [
+  '# Cypress Design System',
+  '',
+  '> Agent-readable guidance for the Cypress Design System: design principles, tokens, voice, accessibility, and component docs. Start with the index, fetch only what the task needs.',
+  '',
+  '## Docs',
+  '',
+  `- [index.md](${BASE_URL}/index.md): router — fetch this first, it points at the rest`,
+  ...docs
+    .filter((path) => path !== 'index.md')
+    .map((path) => `- [${path}](${BASE_URL}/${path})`),
+  '',
+].join('\n')
+writeFileSync(join(root, 'docs', 'public', 'llms.txt'), llmsTxt)


### PR DESCRIPTION
## Problem

Agents consuming the design system docs over HTTP (e.g. Claude Design) use fetch tools with a safety guardrail: they can only fetch absolute URLs that already appear in the conversation or in previously fetched pages. Our agent docs defeated that in two ways:

1. Every cross-doc link under `.agents/` was relative (`./colors.md`), so fetching `agents/index.md` unlocked **nothing** — an agent couldn't follow the router to any pillar or component doc.
2. The index itself wasn't discoverable — nothing on the domain linked to it, so the only way in was a human pasting the URL into every conversation.

## Goal

An agent that can reach `design.cypress.io` by web search should be able to walk the whole guidance tree with no human in the loop: search → homepage → index → everything.

## Changes

- **Absolute links everywhere** — all ~100 relative cross-doc links under `.agents/` rewritten to `https://design.cypress.io/agents/...`. Link text keeps the short path; only hrefs changed. Local repo agents are unaffected (they read via `AGENTS.md` paths).
- **`llms.txt` at the domain root** — generated by `scripts/copy-agents.mjs` during `build:docs` from the actual served tree (93 docs incl. component instructions/ReadMes), so it can't drift. Gitignored like `docs/public/agents/`.
- **Homepage "For AI agents" section** — links the agent index and `llms.txt` so the chain starts from a searchable page (same pattern docs.cypress.io uses).
- **`AGENTS.md`** — documents the absolute-link convention so new links stay absolute.

## Verification

Ran the dev server and confirmed: `/agents/index.md` serves with absolute links and zero remaining relative links, `/llms.txt` lists every served doc, and the homepage renders the new section with both links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and static-site build output only; no runtime product, auth, or data paths change.
> 
> **Overview**
> Agents that fetch design-system guidance over HTTP often can only follow **absolute** URLs, so relative cross-links in `.agents/` blocked navigation from the router to pillar and component docs. This PR rewrites those cross-doc links to `https://design.cypress.io/agents/...` across the agent markdown corpus and documents the convention in **`AGENTS.md`** so new links stay absolute.
> 
> **`scripts/copy-agents.mjs`** now emits **`docs/public/llms.txt`** (gitignored, built with **`build:docs`**) listing every served `.md` with absolute URLs so the full tree is discoverable from the domain root. The docs homepage gains a **For AI agents** section pointing at the index and **`llms.txt`**, matching the intended path: searchable site → index → rest of the guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1e02a92c590c9ef02439f609f3986c48988fe1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->