### PR TITLE
test(Select): stage 4 — keyboard reach for in-list buttons + popover aria-label

### DIFF
--- a/components/Select/assertions.ts
+++ b/components/Select/assertions.ts
@@ -293,6 +293,33 @@ export default function assertions(
       cy.findByRole('option', { name: 'Gamma' }).should('not.exist')
     })
 
+    it('keyboard nav still walks rows while the search input is focused', () => {
+      const onChange = cy.stub().as('onChange')
+      mountStory({
+        items: simpleItems,
+        searchable: true,
+        searchPlaceholder: 'Find item',
+        onChange,
+      })
+      cy.findByRole('button').click()
+      // Focus the search input and type; the wrapper's keydown listener
+      // catches bubbled arrow keys, so focus walks rows even with the
+      // input active.
+      cy.findByPlaceholderText('Find item').focus().type('a')
+      // 'a' matches Alpha and Gamma. ArrowDown lands on Alpha.
+      cy.findByPlaceholderText('Find item').type('{downArrow}')
+      cy.findByRole('option', { name: 'Alpha' }).should(
+        'have.attr',
+        'data-focused',
+        'true',
+      )
+      // Enter on the focused row selects it and closes the popover.
+      cy.findByPlaceholderText('Find item').type('{enter}')
+      cy.get('@onChange').should('have.been.calledOnce')
+      cy.get('@onChange').its('firstCall.args.0').should('equal', 'alpha')
+      cy.findByRole('listbox').should('not.exist')
+    })
+
     it('orphan headlines collapse after filtering', () => {
       mountStory({
         items: mixedItems,
@@ -321,6 +348,23 @@ export default function assertions(
       cy.findByRole('option', { name: 'Alpha' }).should('exist')
       cy.findByRole('option', { name: 'Beta' }).should('exist')
       cy.findByRole('option', { name: 'Gamma' }).should('exist')
+    })
+
+    // ---------------- accessibility ----------------
+
+    it('popover has aria-label = headerTitle when set, "Options" otherwise', () => {
+      // No headerTitle → fallback label.
+      mountStory({ items: simpleItems, defaultOpen: true })
+      cy.findByRole('listbox').should('have.attr', 'aria-label', 'Options')
+    })
+
+    it('popover aria-label uses headerTitle when provided', () => {
+      mountStory({
+        items: simpleItems,
+        headerTitle: 'Pick a team',
+        defaultOpen: true,
+      })
+      cy.findByRole('listbox').should('have.attr', 'aria-label', 'Pick a team')
     })
 
     // ---------------- header ----------------

--- a/components/Select/assertions.ts
+++ b/components/Select/assertions.ts
@@ -229,6 +229,31 @@ export default function assertions(
       cy.get('@rowAction').should('have.been.calledOnce')
     })
 
+    it('button-row is reachable by keyboard (ArrowDown lands focus, Enter fires onClick)', () => {
+      const onClick = cy.stub().as('rowAction')
+      const items: SelectItem[] = [
+        { label: 'Alpha', value: 'alpha' },
+        { type: 'button', key: 'add', label: 'Add new', onClick },
+      ]
+      mountStory({ items, placeholder: 'Open' })
+      // 1st ArrowDown opens with no focus; 2nd lands on Alpha; 3rd wraps to
+      // the button row (no divider between, so 2 interactive rows total).
+      cy.findByRole('button', { name: 'Open' })
+        .focus()
+        .type('{downArrow}{downArrow}{downArrow}')
+      // The row wrapper (role="presentation") carries `data-focused`; the
+      // inner Button is just the action target. Walk up via `closest`.
+      cy.findByRole('listbox')
+        .findByRole('button', { name: 'Add new' })
+        .closest('[role="presentation"]')
+        .should('have.attr', 'data-focused', 'true')
+      // Enter on the focused button row should fire its onClick. Popover
+      // stays open so the consumer can decide whether to close it.
+      cy.findByRole('button', { name: 'Open' }).type('{enter}')
+      cy.get('@rowAction').should('have.been.calledOnce')
+      cy.findByRole('listbox').should('be.visible')
+    })
+
     it('checkbox row toggles on/off; popover stays open; emits undefined on untoggle', () => {
       const onChange = cy.stub().as('onChange')
       mountStory({ items: checkboxItems, onChange })

--- a/components/Select/constants/src/filter-items.ts
+++ b/components/Select/constants/src/filter-items.ts
@@ -1,5 +1,5 @@
 import type { SelectItem } from './index'
-import { getItemLabel, isSelectable } from './index'
+import { getItemLabel, isInteractive, isSelectable } from './index'
 
 /**
  * Filter items by case-insensitive substring match against `label`.
@@ -50,12 +50,26 @@ export function filterAndCollapseHeadlines(
 }
 
 /**
- * Indices of items that participate in keyboard traversal and selection.
+ * Indices of items that can be SELECTED (set as the Select's value).
+ * Used for the checkbox / aria-selected mapping. Headlines, dividers,
+ * buttons, and value-less custom rows are excluded.
  */
 export function getSelectableIndices(items: SelectItem[]): number[] {
   const out: number[] = []
   items.forEach((item, i) => {
     if (isSelectable(item)) out.push(i)
+  })
+  return out
+}
+
+/**
+ * Indices that keyboard nav walks — selectable rows plus `button` rows so
+ * in-list actions are reachable without a pointer.
+ */
+export function getInteractiveIndices(items: SelectItem[]): number[] {
+  const out: number[] = []
+  items.forEach((item, i) => {
+    if (isInteractive(item)) out.push(i)
   })
   return out
 }

--- a/components/Select/constants/src/index.ts
+++ b/components/Select/constants/src/index.ts
@@ -103,7 +103,9 @@ export type SelectItem =
   | SelectItemButton
   | SelectItemCustom
 
-// Subset of items that participate in selection / keyboard traversal.
+// Subset of items that participate in **selection** (the value the Select
+// reports). Headlines / dividers / buttons / value-less custom rows are
+// excluded.
 export type SelectableItem =
   | SelectItemDefault
   | SelectItemCheckbox
@@ -117,6 +119,14 @@ export function isSelectable(item: SelectItem): item is SelectableItem {
   if (item.type === 'user') return !item.disabled
   if (item.type === 'custom') return typeof item.value === 'string'
   return false
+}
+
+// Superset of `isSelectable` that also includes `button` rows — these are
+// not selectable (they have no value) but ARE reachable by keyboard:
+// arrows walk them, and Enter fires the row's `onClick`. Headlines and
+// dividers stay off the keyboard path.
+export function isInteractive(item: SelectItem): boolean {
+  return isSelectable(item) || item.type === 'button'
 }
 
 export function getItemValue(item: SelectItem): string | undefined {

--- a/components/Select/instructions.md
+++ b/components/Select/instructions.md
@@ -250,7 +250,7 @@ The Trigger inherits Button's states (`default`, `hover`, `focused`, `focus-visi
 ## Accessibility
 
 - Trigger is a `<button type="button">` (Cypress `Button` component) with `aria-haspopup="listbox"`, `aria-expanded`, and `aria-controls` pointing at the popover. We use the "button + listbox popup" pattern (same as Radix and Headless UI) rather than `role="combobox"`, because combobox per ARIA implies an editable text input — which the default trigger isn't.
-- Popover has `role="listbox"`.
+- Popover has `role="listbox"` and an `aria-label` so screen readers announce it on open. The label is `headerTitle` when set, otherwise the literal string `"Options"`. Consumers wanting a different label can drive it via `headerTitle`.
 - Selectable rows have `role="option"` + `aria-selected`. Non-selectable rows (`headline`, `divider`, `button`) have `role="presentation"`.
 - Disabled rows have `aria-disabled="true"` (they are `<div>` elements, not `<button>` / `<input>`, so the HTML `disabled` attribute does not apply).
 - Focus stays on the trigger while the popover is open; arrow-key traversal is reflected via `aria-activedescendant` on the trigger, pointing at the currently-focused row's id. The visual focus ring is driven by `data-focused="true"` on the row, not by DOM focus.

--- a/components/Select/instructions.md
+++ b/components/Select/instructions.md
@@ -257,8 +257,8 @@ The Trigger inherits Button's states (`default`, `hover`, `focused`, `focus-visi
 - Keyboard support:
   - `Enter` / `Space` on the trigger → toggle open.
   - `ArrowDown` on the trigger → open (does not focus a row yet; the next arrow keypress lands focus — see below).
-  - Open with no row focused. The first `ArrowDown` lands focus on the first selectable row; the first `ArrowUp` lands focus on the last. Subsequent `ArrowUp` / `ArrowDown` walk previous / next selectable rows (skipping `headline`, `divider`, `button`, and `disabled`).
-  - `Enter` on a focused row → select + close. No-op while nothing is focused. (`button` rows are intentionally excluded from keyboard traversal in v1; trigger them with the pointer. Reach via keyboard is tracked for the accessibility branch.)
+  - Open with no row focused. The first `ArrowDown` lands focus on the first interactive row; the first `ArrowUp` lands focus on the last. Subsequent `ArrowUp` / `ArrowDown` walk previous / next interactive rows (skipping `headline`, `divider`, and `disabled`). **`button` rows are included** so in-list actions are reachable by keyboard.
+  - `Enter` on a focused row → select + close (for selectable rows), or fire the row's `onClick` (for `button` rows, which stay open afterward). No-op while nothing is focused.
   - `Escape` → close + return focus to the trigger.
   - `Tab` → close and move focus naturally.
 

--- a/components/Select/react/Select.tsx
+++ b/components/Select/react/Select.tsx
@@ -6,6 +6,7 @@ import type { ButtonVariants } from '@cypress-design/constants-button'
 import * as SelectConstants from '@cypress-design/constants-select'
 import {
   filterAndCollapseHeadlines,
+  getInteractiveIndices,
   getSelectableIndices,
 } from '@cypress-design/constants-select'
 import type {
@@ -175,8 +176,11 @@ export const Select: React.FC<SelectProps> = ({
         : items,
     [items, searchable, searchFilters, searchValue],
   )
+  // Keyboard nav walks `interactive` indices (selectable rows + button
+  // rows) so in-list actions are reachable. handleSelect still
+  // distinguishes selectable rows from button rows.
   const selectableIndices = React.useMemo(
-    () => getSelectableIndices(displayItems),
+    () => getInteractiveIndices(displayItems),
     [displayItems],
   )
 
@@ -325,6 +329,16 @@ export const Select: React.FC<SelectProps> = ({
     // Belt to the close-on-disabled-flip effect above: a click that was
     // already in flight when `disabled` flipped should not mutate `value`.
     if (disabled) return
+    // Button rows aren't selectable (no value) — they fire their own
+    // onClick when picked via keyboard. The pointer path goes through
+    // `SelectOptionItem` and reaches the Button directly; here we only
+    // see keyboard Enter on a focused row. Don't close the popover so
+    // multi-action flows are possible; the consumer's onClick can close
+    // via `onOpenChange` if needed.
+    if (item.type === 'button') {
+      item.onClick()
+      return
+    }
     const itemValue = SelectConstants.getItemValue(item)
     if (itemValue === undefined) return
     // Checkbox rows toggle: clicking an already-checked row unchecks it.

--- a/components/Select/react/Select.tsx
+++ b/components/Select/react/Select.tsx
@@ -7,7 +7,6 @@ import * as SelectConstants from '@cypress-design/constants-select'
 import {
   filterAndCollapseHeadlines,
   getInteractiveIndices,
-  getSelectableIndices,
 } from '@cypress-design/constants-select'
 import type {
   SelectItem,

--- a/components/Select/react/SelectOptionItem.tsx
+++ b/components/Select/react/SelectOptionItem.tsx
@@ -108,6 +108,7 @@ export const SelectOptionItem: React.FC<SelectOptionItemProps> = ({
           SelectConstants.CssButtonRowClasses,
           SelectConstants.CssOptionItemHeightClasses[size],
           SelectConstants.CssOptionItemPaddingClasses[size],
+          SelectConstants.CssButtonRowFocusClasses[theme],
         )}
       >
         <Button

--- a/components/Select/react/SelectOptionItem.tsx
+++ b/components/Select/react/SelectOptionItem.tsx
@@ -101,7 +101,9 @@ export const SelectOptionItem: React.FC<SelectOptionItemProps> = ({
       // <Button>; matches headline/divider so the listbox tree only
       // exposes selectable rows to assistive tech.
       <div
+        id={id}
         role="presentation"
+        data-focused={focused || undefined}
         className={clsx(
           SelectConstants.CssButtonRowClasses,
           SelectConstants.CssOptionItemHeightClasses[size],

--- a/components/Select/react/SelectOptionList.tsx
+++ b/components/Select/react/SelectOptionList.tsx
@@ -142,6 +142,7 @@ export const SelectOptionList: React.FC<SelectOptionListProps> = ({
     <div
       id={id}
       role="listbox"
+      aria-label={headerTitle || 'Options'}
       style={panelStyle}
       className={clsx(
         SelectConstants.CssPopoverLayoutClasses,

--- a/components/Select/react/SelectOptionList.tsx
+++ b/components/Select/react/SelectOptionList.tsx
@@ -108,13 +108,24 @@ export const SelectOptionList: React.FC<SelectOptionListProps> = ({
   const HeaderIconLeft = headerIconLeftRaw as IconComponent | undefined
   const HeaderIconRight = headerIconRightRaw as IconComponent | undefined
 
-  const selectableIndices = React.useMemo(
+  // Two different "navigable" sets for the panel:
+  //   * `interactiveIndices` — rows the keyboard can land on (includes
+  //     in-list `button` rows so they're keyboard-reachable);
+  //   * `selectableIndices`  — rows the user can pick as a value (excludes
+  //     buttons). Used only to decide whether to show "No results" — when
+  //     search filters out every selectable row, the empty state still
+  //     fires even if a button (e.g. "+ Add new") survives the filter.
+  const interactiveIndices = React.useMemo(
     () => getInteractiveIndices(items),
+    [items],
+  )
+  const selectableIndices = React.useMemo(
+    () => getSelectableIndices(items),
     [items],
   )
   const focusedSelectableIndex =
     typeof focusedIndex === 'number'
-      ? selectableIndices[focusedIndex]
+      ? interactiveIndices[focusedIndex]
       : undefined
 
   const hasTitleRow = Boolean(

--- a/components/Select/react/SelectOptionList.tsx
+++ b/components/Select/react/SelectOptionList.tsx
@@ -19,7 +19,10 @@ import type {
   SelectFooterProps,
   SelectSizingProps,
 } from '@cypress-design/constants-select'
-import { getSelectableIndices } from '@cypress-design/constants-select'
+import {
+  getInteractiveIndices,
+  getSelectableIndices,
+} from '@cypress-design/constants-select'
 import SelectOptionItem from './SelectOptionItem'
 
 // Composed from the same shared groups as SelectProps so the popover's
@@ -106,7 +109,7 @@ export const SelectOptionList: React.FC<SelectOptionListProps> = ({
   const HeaderIconRight = headerIconRightRaw as IconComponent | undefined
 
   const selectableIndices = React.useMemo(
-    () => getSelectableIndices(items),
+    () => getInteractiveIndices(items),
     [items],
   )
   const focusedSelectableIndex =

--- a/components/Select/vue/Select.vue
+++ b/components/Select/vue/Select.vue
@@ -14,7 +14,6 @@ import * as SelectConstants from '@cypress-design/constants-select'
 import {
   filterAndCollapseHeadlines,
   getInteractiveIndices,
-  getSelectableIndices,
 } from '@cypress-design/constants-select'
 import type {
   SelectItem,

--- a/components/Select/vue/Select.vue
+++ b/components/Select/vue/Select.vue
@@ -13,6 +13,7 @@ import type { ButtonVariants } from '@cypress-design/constants-button'
 import * as SelectConstants from '@cypress-design/constants-select'
 import {
   filterAndCollapseHeadlines,
+  getInteractiveIndices,
   getSelectableIndices,
 } from '@cypress-design/constants-select'
 import type {
@@ -182,8 +183,11 @@ const displayItems = computed(() =>
 // -1 means "no row focused" — visual focus ring + aria-activedescendant are
 // suppressed until the user actually navigates with an arrow key.
 const focusedIndex = ref(-1)
+// Keyboard nav walks `interactive` indices (selectable rows + button rows)
+// so in-list actions are reachable. Selection logic in handleSelect still
+// distinguishes selectable rows from button rows.
 const selectableIndices = computed(() =>
-  getSelectableIndices(displayItems.value),
+  getInteractiveIndices(displayItems.value),
 )
 
 watch(open, (isOpen) => {
@@ -329,6 +333,15 @@ function handleSelect(item: SelectItem) {
   // Belt to the close-on-disabled-flip watcher above: a click that was
   // already in flight when `disabled` flipped should not mutate the value.
   if (props.disabled) return
+  // Button rows aren't selectable (no value) — they fire their own onClick
+  // when picked via keyboard. The pointer path goes through `_SelectOptionItem`
+  // and reaches the Button directly; here we only see keyboard Enter on a
+  // focused row. Don't close the popover so multi-action flows are
+  // possible; the consumer's onClick can close via `update:open` if needed.
+  if (item.type === 'button') {
+    item.onClick()
+    return
+  }
   const itemValue = SelectConstants.getItemValue(item)
   if (itemValue === undefined) return
   // Checkbox rows toggle: clicking an already-checked row unchecks it.

--- a/components/Select/vue/_SelectOptionItem.vue
+++ b/components/Select/vue/_SelectOptionItem.vue
@@ -126,6 +126,7 @@ function onMouseDown(e: MouseEvent) {
       SelectConstants.CssButtonRowClasses,
       SelectConstants.CssOptionItemHeightClasses[size],
       SelectConstants.CssOptionItemPaddingClasses[size],
+      SelectConstants.CssButtonRowFocusClasses[theme],
     ]"
   >
     <Button

--- a/components/Select/vue/_SelectOptionItem.vue
+++ b/components/Select/vue/_SelectOptionItem.vue
@@ -119,7 +119,9 @@ function onMouseDown(e: MouseEvent) {
        selectable rows to assistive tech. -->
   <div
     v-else-if="item.type === 'button'"
+    :id="id"
     role="presentation"
+    :data-focused="focused || undefined"
     :class="[
       SelectConstants.CssButtonRowClasses,
       SelectConstants.CssOptionItemHeightClasses[size],

--- a/components/Select/vue/_SelectOptionList.vue
+++ b/components/Select/vue/_SelectOptionList.vue
@@ -132,7 +132,13 @@ function rowId(index: number): string | undefined {
 </script>
 
 <template>
-  <div :id="id" role="listbox" :style="panelStyle" :class="panelClasses">
+  <div
+    :id="id"
+    role="listbox"
+    :aria-label="headerTitle || 'Options'"
+    :style="panelStyle"
+    :class="panelClasses"
+  >
     <div v-if="hasHeader" :class="SelectConstants.CssHeaderContainerClasses">
       <!-- Title row: button · iconLeft · title · tag · (spacer) · iconRight.
            Carries its own bottom border so a separator appears between the

--- a/components/Select/vue/_SelectOptionList.vue
+++ b/components/Select/vue/_SelectOptionList.vue
@@ -10,7 +10,10 @@ import {
   IconActionInfoOutline,
 } from '@cypress-design/vue-icon'
 import * as SelectConstants from '@cypress-design/constants-select'
-import { getSelectableIndices } from '@cypress-design/constants-select'
+import {
+  getInteractiveIndices,
+  getSelectableIndices,
+} from '@cypress-design/constants-select'
 import type {
   SelectItem,
   SelectAlignment,
@@ -67,7 +70,7 @@ function onHeaderTabSwitch(tab: { id: string }) {
   emit('header-tab-change', tab.id)
 }
 
-const selectableIndices = computed(() => getSelectableIndices(props.items))
+const selectableIndices = computed(() => getInteractiveIndices(props.items))
 const focusedSelectableIndex = computed(() =>
   typeof props.focusedIndex === 'number'
     ? selectableIndices.value[props.focusedIndex]

--- a/components/Select/vue/_SelectOptionList.vue
+++ b/components/Select/vue/_SelectOptionList.vue
@@ -70,10 +70,18 @@ function onHeaderTabSwitch(tab: { id: string }) {
   emit('header-tab-change', tab.id)
 }
 
-const selectableIndices = computed(() => getInteractiveIndices(props.items))
+// Two different "navigable" sets for the panel:
+//   * `interactiveIndices` — rows the keyboard can land on (includes
+//     in-list `button` rows so they're keyboard-reachable);
+//   * `selectableIndices`  — rows the user can pick as a value (excludes
+//     buttons). Used only to decide whether to show "No results" — when
+//     search filters out every selectable row, the empty state still
+//     fires even if a button (e.g. "+ Add new") survives the filter.
+const interactiveIndices = computed(() => getInteractiveIndices(props.items))
+const selectableIndices = computed(() => getSelectableIndices(props.items))
 const focusedSelectableIndex = computed(() =>
   typeof props.focusedIndex === 'number'
-    ? selectableIndices.value[props.focusedIndex]
+    ? interactiveIndices.value[props.focusedIndex]
     : undefined,
 )
 


### PR DESCRIPTION
## Summary

Stage 4 (accessibility) of the Select component work. Two user-facing improvements, plus a small test addition that locks in the search+keyboard interaction we accidentally fixed during stage-3 review.

### Changes

- **Button rows reachable by keyboard.** Closes the deferred-to-a11y item in `instructions.md`. Adds `isInteractive` / `getInteractiveIndices` (selectable rows + button rows) so arrows walk button rows; `handleSelect` special-cases `item.type === 'button'` to fire `onClick` without closing the popover.
- **`aria-label` on popover.** Listbox now has `aria-label` = `headerTitle` when set, otherwise the literal `"Options"`, so screen readers announce something meaningful on open.
- **Search input ↔ keyboard nav.** New shared assertion verifies that arrow keys walk rows while the search input is focused (mechanism already worked after stage-3's `searchValue` lift; the test just locks it in).

### Stacked on PR #691

Base branch: `select-tests`. The 4-PR stack now reads:
- #667 `select-instructions` → `main`
- #668 `select-component` → `select-instructions`
- #691 `select-tests` → `select-component`
- **this PR** `select-accessibility` → `select-tests`

### Test plan

- [x] `yarn cy:run --component --spec 'components/Select/**/*.cy.tsx'` — **59/59 passing, 0 skipped**
- [x] Verified in docs preview: ArrowDown reaches the "+ Add new" button row in the "Items + action" demo; popover with `headerTitle="Header headline"` gets `aria-label="Header headline"`, popover without `headerTitle` gets `aria-label="Options"`
- [x] Focus-visible audit on every tab-reachable element inside an open popover (trigger, search input, header back button, footer button) — already correct via Button/Textbox/Tabs component styles. Tabs has no explicit `focus-visible:` ring but relies on browser default — out-of-scope for Select.

### Out of scope (deferred follow-ups)

- Auto-focus the search input when popover opens (would close the "search field is reachable only by mouse" gap; bigger UX change, can land later).
- Tabs component focus-visible ring (upstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Focused a11y and keyboard behavior in a design-system Select with broad Cypress coverage; no auth, data, or breaking API changes beyond improved keyboard semantics for button rows.
> 
> **Overview**
> Stage 4 accessibility for **Select**: keyboard users can reach in-list **button** rows (e.g. “Add new”), and the popover listbox gets a meaningful **`aria-label`**.
> 
> **Keyboard navigation** now walks **interactive** rows—selectable options plus `type: 'button'`—via new `isInteractive` / `getInteractiveIndices` in shared constants. React and Vue `Select` use that set for arrow keys and `aria-activedescendant`; **Enter** on a focused button row runs `onClick` and **leaves the popover open** (unlike normal selection). Button row wrappers get `id`, `data-focused`, and focus ring styles so keyboard focus is visible.
> 
> The popover **`role="listbox"`** element uses **`aria-label={headerTitle || 'Options'}`** in both frameworks. **`instructions.md`** documents the updated keyboard and labeling behavior.
> 
> **Tests** add Cypress coverage for keyboard button rows, search-input + arrow/Enter selection, and both `aria-label` cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd95faeda66ca902587370fb54678d3882ec2321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->