### PR TITLE
feat(icons): add time-clock-small at 16px

### DIFF
--- a/.changeset/add-time-clock-small-icon.md
+++ b/.changeset/add-time-clock-small-icon.md
@@ -1,0 +1,7 @@
+---
+'@cypress-design/icon-registry': minor
+'@cypress-design/react-icon': minor
+'@cypress-design/vue-icon': minor
+---
+
+Add `time-clock-small` at 16px (`IconTimeClockSmall`) — a compact dual-tone clock glyph with `strokeColor` + `fillColor` slots, sized down from the existing `time-clock` 16px so it reads at rows and dense UI.

--- a/icon-registry/icons-static/time-clock-small_x16.svg
+++ b/icon-registry/icons-static/time-clock-small_x16.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M8 14C11.3137 14 14 11.3137 14 8C14 4.68629 11.3137 2 8 2C4.68629 2 2 4.68629 2 8C2 11.3137 4.68629 14 8 14Z" fill="#D0D2E0" class="icon-light" />
+  <path d="M8 5V8L9.5 9M14 8C14 11.3137 11.3137 14 8 14C4.68629 14 2 11.3137 2 8C2 4.68629 4.68629 2 8 2C11.3137 2 14 4.68629 14 8Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon-dark" />
+</svg>


### PR DESCRIPTION
## What & why

We already have `time-clock` at 16 and 24, but both are the standard outline-only variant. Some surfaces (dense rows, inline metadata, small pills) need a more legible clock at 16px — outline strokes at that size read thin against tinted backgrounds. This adds a compact dual-tone `time-clock-small` at 16px so consumers pick the right variant based on context, matching the pattern we just landed for `object-pencil`.

## How

SVG pulled from the Design System Figma ([node](https://www.figma.com/design/1WJ3GVQyMV5e7xVxPg3yID/Design-System?node-id=22244-242)) and normalized to the repo's `icon-dark` / `icon-light` class convention. Light-fill circle keeps `#D0D2E0` as a literal fallback so the glyph still renders correctly when `fillColor` isn't passed, matching the `building-*` and `object-pencil` families.

Registered via the existing `icon-registry/build-icons.mjs` pass — no changes to the icon component packages required, they pick it up automatically. Regenerated `src/icons.ts` locally to confirm `IconTimeClockSmall` shows up with `strokeColor` + `fillColor` slots at 16px.

Changeset marks it as a `minor` bump for `@cypress-design/icon-registry`, `@cypress-design/react-icon`, and `@cypress-design/vue-icon`.

## Where to focus review

- **Naming.** `time-clock-small` sits alongside `time-clock` (16, 24). Kept the `time-` prefix rather than promoting the small variant to `action-*` / `object-*`, since it's a size/style variant of an existing time glyph, not a new concept.
- **Two-tone default.** Unlike the outline `time-clock`, `-small` ships as a dual-tone glyph so it can carry a distinct background disc. Flagging it so it isn't a surprise in the API — the color-channel dropdown will show `s`+`f` for this variant vs. `s` only for the outline sizes.

## Test plan

- [x] `node icon-registry/build-icons.mjs` regenerates `src/icons.ts` and includes `IconTimeClockSmall` with `strokeColor` + `fillColor` slots at 16px.
- [x] Rendered `time-clock-small_x16.svg` locally and confirmed shape matches Figma reference.
- [ ] Docs `/icons` page — verify glyph renders in both themes and the color-channel dropdown shows `s`+`f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive icon asset and registry entry only; no runtime or auth/data logic changes.
> 
> **Overview**
> Adds a new **`time-clock-small`** 16px icon (`IconTimeClockSmall`) as a **dual-tone** clock variant (filled disc + stroked hands) for dense UI, alongside the existing outline-only **`time-clock`** at 16/24px.
> 
> The glyph is a new static SVG using the repo’s **`icon-light`** / **`icon-dark`** classes with **`strokeColor`** and **`fillColor`** slots; registration flows through the existing icon build with **no** changes to React/Vue icon packages. A changeset bumps **`@cypress-design/icon-registry`**, **`react-icon`**, and **`vue-icon`** as **minor**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0256e0de16616f5ed66e3ea462f98a0f41d28036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->