### PR TITLE
fix(react): UMD interop so default-imported siblings resolve via .default

### DIFF
--- a/.changeset/fix-runresults-umd-interop.md
+++ b/.changeset/fix-runresults-umd-interop.md
@@ -1,0 +1,5 @@
+---
+'@cypress-design/react-runresults': patch
+---
+
+Fix UMD build interop so default-imported sibling `@cypress-design/react-*` components resolve via `.default` (Rollup `interop: 'auto'`), removing the need for consumer-side ESM aliases.

--- a/.changeset/fix-select-umd-interop.md
+++ b/.changeset/fix-select-umd-interop.md
@@ -1,0 +1,5 @@
+---
+'@cypress-design/react-select': patch
+---
+
+Fix UMD build interop so default-imported sibling `@cypress-design/react-*` components resolve via `.default` (Rollup `interop: 'auto'`), removing the need for consumer-side ESM aliases.

--- a/components/react.rollup.config.mjs
+++ b/components/react.rollup.config.mjs
@@ -11,6 +11,14 @@ export default ({ input, plugins = [], external = [] }) => ({
       file: './dist/index.umd.js',
       format: 'cjs',
       exports: 'auto',
+      // Rollup 3+ defaults `output.interop` to 'default', which emits bare
+      // `require('@cypress-design/react-*')` for default-imported sibling
+      // packages. Those siblings are `__esModule` with the component on
+      // `.default`, so a bare require returns the module namespace object and
+      // React tries to render a module -> crash. 'auto' emits a runtime
+      // `_interopDefault` (`__esModule` check) so defaults resolve via
+      // `.default`, removing the need for consumer-side ESM aliases.
+      interop: 'auto',
       sourcemap: true,
     },
     {


### PR DESCRIPTION
## Problem

The shared React-component Rollup config, `components/react.rollup.config.mjs`, builds the UMD/CJS artifact (`dist/index.umd.js`, `format: 'cjs'`) using Rollup 3+'s default `output.interop: 'default'`.

For any component that **default-imports** an external sibling `@cypress-design/react-*` package, that default produces a **bare** `require(...)` with no interop wrapper:

```js
// before (dist/index.umd.js)
var StatusIcon = require('@cypress-design/react-statusicon');
var Tooltip    = require('@cypress-design/react-tooltip');
...
React.createElement(StatusIcon, { ... })   // StatusIcon is the whole module object
```

The sibling packages are compiled as `__esModule` with the component on `.default`, so `require()` returns the **module namespace object**. React then tries to render a module → runtime crash.

This is why the downstream consumer (cypress-services) had to add webpack ESM aliases forcing `@cypress-design/react-runresults` to resolve to `dist/index.es.mjs`. The durable fix belongs here, in the build config.

## Fix

Set `interop: 'auto'` on the CJS output object in `components/react.rollup.config.mjs`. Rollup then emits its runtime `_interopDefault` helper (an `__esModule` check) so default imports resolve via `.default`:

```js
// after (dist/index.umd.js)
var StatusIcon = require('@cypress-design/react-statusicon');
var Tooltip    = require('@cypress-design/react-tooltip');
function _interopDefault (e) { return e && e.__esModule ? e : { default: e }; }
var StatusIcon__default = /*#__PURE__*/_interopDefault(StatusIcon);
var Tooltip__default    = /*#__PURE__*/_interopDefault(Tooltip);
...
React.createElement(StatusIcon__default.default, { ... })   // real default export
```

The ESM output (`dist/index.es.mjs`) is untouched.

## Scope / why two changesets

Both `react-runresults` and `react-select` get a patch changeset because they are the **only** components that default-import `__esModule` `@cypress-design` siblings, and thus the only ones whose behavior changes:

- `react-runresults` → `react-statusicon`, `react-tooltip`
- `react-select` → `react-button`, `react-checkbox`, `react-tabs`, `react-tag`, `react-textbox`

**Note on other components:** because `interop: 'auto'` applies to every default-imported external, most other react components' UMD output also gains a `clsx__default` (and, for `Accordion`, a `react`) interop wrapper. `clsx`/`react` are plain CJS (not `__esModule`), so `_interopDefault` returns `{ default: e }` and `.default` yields the same value as before — **behaviorally neutral**. Only the two packages above have an actual behavior change, so only they are versioned. `dist/` is not committed, so this PR's diff is just the config plus the two changesets. (If maintainers prefer to version every component whose emitted bytes change, that is a one-line-per-package addition — flagging for your call.)

## Verification

**Upstream (this repo):**
- Built `react-runresults` and `react-select`; confirmed the sibling `require(...)`s are now `_interopDefault`-wrapped and consumed via `.default`.
- Component tests pass: `RunResultsReact` (29), `RunResultsA11yReact` (5), `SelectReact` (31) → 65/65.

**Downstream link-verify (cypress-services PR #13736, changes reverted after):**
- Copied the freshly-built `react-runresults` `dist/` into cypress-services and **removed both webpack ESM aliases** (dashboard + design-system).
- `RunsListItem.spec.tsx` component test: 19/19 pass.
- `RunDetails_spec.ts` + `listing_1_spec.ts` e2e: 29/29 pass.
- **Negative control:** restoring the old (pre-fix) UMD with the aliases still removed makes all 19 component tests fail (the original crash) — confirming the upstream `interop: 'auto'` change (not webpack picking ESM) is what resolves it.

## Impact

Unblocks cypress-services PR #13736 ("Replace in-house RunStats with `@cypress-design/react-runresults`") by letting it drop the consumer-side ESM aliases, and addresses the reviewer's request to fix this upstream in the build config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-output interop change with verified tests; ESM artifacts unchanged and other packages’ extra interop wrappers are behaviorally neutral for plain CJS deps.
> 
> **Overview**
> Sets **`interop: 'auto'`** on the CJS/UMD output in the shared **`components/react.rollup.config.mjs`**, so Rollup emits `_interopDefault` helpers for default-imported externals instead of bare `require()` calls.
> 
> That fixes runtime crashes when UMD consumers load packages like **`@cypress-design/react-runresults`** and **`@cypress-design/react-select`**, which default-import sibling **`@cypress-design/react-*`** packages built as `__esModule` (the component lives on `.default`). ESM **`dist/index.es.mjs`** output is unchanged.
> 
> Patch changesets are added for **`react-runresults`** and **`react-select`** as the packages whose UMD behavior actually changes, so downstream apps (e.g. cypress-services) can drop webpack ESM aliases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59445dd3e05c81cc995c2bd49a7ab89f3a950414. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->