### PR TITLE
ci: give Percy a per-attempt parallel nonce so re-runs can finalize

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,3 +134,9 @@ jobs:
           # build finalization"). strategy.job-total tracks the `container`
           # matrix size automatically.
           PERCY_PARALLEL_TOTAL: ${{ strategy.job-total }}
+          # Percy derives its parallel nonce from GITHUB_RUN_ID alone, so a
+          # re-run of a failed shard reuses the build the first attempt already
+          # finalized and dies with "Can only finalize pending builds". Include
+          # the attempt, mirroring `ci-build-id` above, so every re-run gets a
+          # fresh Percy build.
+          PERCY_PARALLEL_NONCE: ${{ github.run_id }}-${{ github.run_attempt }}


### PR DESCRIPTION
## Problem

Re-running a failed component-test shard fails at the Percy step even when every spec passes:

```
[percy] Error: Can only finalize pending builds, current state: finished
##[error]The process '.../npx' failed with exit code 1
```

Percy derives its `--parallel` nonce from `GITHUB_RUN_ID` alone, so attempt 2 reuses the Percy build attempt 1 already finalized. This blocked the release on [run 34534538363 attempt 2](https://github.com/cypress-io/cypress-design/actions/runs/34534538363/attempts/2), where the only attempt-1 failure was an unrelated `DocMenu` sub-pixel flake that passed on retry.

## Fix

Set `PERCY_PARALLEL_NONCE` to `run_id-run_attempt`, matching what `ci-build-id` already does for Cypress Cloud, so each attempt gets its own Percy build. One env var, no behavior change on first attempts.

No changeset: CI config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only environment variable change with no application or runtime impact.
> 
> **Overview**
> **Fixes Percy failing on GitHub Actions workflow re-runs** by setting `PERCY_PARALLEL_NONCE` to `${{ github.run_id }}-${{ github.run_attempt }}` on the component Cypress job (alongside the existing `PERCY_PARALLEL_TOTAL`).
> 
> Without this, Percy keys parallel builds only on `GITHUB_RUN_ID`, so a re-run tries to finalize an already-finished build and errors with *"Can only finalize pending builds"*. The nonce now matches the `ci-build-id` pattern Cypress Cloud already uses, so each attempt gets a separate Percy build while first attempts behave the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f7390e8280feaeb22d590694d070405bba4ec7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->