### PR TITLE
fix(statusicon): use * for the internal react-icon dep like every other package

### DIFF
--- a/components/StatusIcon/react/package.json
+++ b/components/StatusIcon/react/package.json
@@ -20,7 +20,7 @@
     "build:types": "tsc --project ./tsconfig.build.json"
   },
   "dependencies": {
-    "@cypress-design/react-icon": "^3.0.0",
+    "@cypress-design/react-icon": "*",
     "clsx": "*"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1682,7 +1682,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@cypress-design/react-icon@npm:*, @cypress-design/react-icon@npm:^3.0.0, @cypress-design/react-icon@workspace:components/Icon/react":
+"@cypress-design/react-icon@npm:*, @cypress-design/react-icon@workspace:components/Icon/react":
   version: 0.0.0-use.local
   resolution: "@cypress-design/react-icon@workspace:components/Icon/react"
   dependencies:
@@ -1788,7 +1788,7 @@ __metadata:
   resolution: "@cypress-design/react-statusicon@workspace:components/StatusIcon/react"
   dependencies:
     "@cypress-design/constants-statusicon": "npm:*"
-    "@cypress-design/react-icon": "npm:^3.0.0"
+    "@cypress-design/react-icon": "npm:*"
     "@cypress-design/rollup-plugin-tailwind-keep": "npm:*"
     clsx: "npm:*"
   languageName: unknown


### PR DESCRIPTION
## Problem

The release PR #721 fails `yarn install --immutable` in Build, on Vercel, and would fail the same way in the Release job after merge, so nothing would publish.

`react-statusicon` is the only workspace that pins an internal dependency to a real range (`@cypress-design/react-icon: ^3.0.0`, written by the bot in the #705 release PR). Changesets rewrites real ranges on every release (`updateInternalDependencies: patch`), which changes what `yarn.lock` must contain, and the bot never regenerates the lockfile.

## Fix

Switch the dep back to `*`, matching every other component. `scripts/set-version.mjs` resolves `*` to the real `^version` at publish time, so the published `package.json` is unchanged. Verified locally that `yarn install --immutable` passes on this branch.

No changeset: `react-statusicon` is already patch-bumped in the pending release and the published output is identical.

Once merged, the bot regenerates #721 without touching any dependency ranges, and that PR should go green and be safe to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and lockfile-only change; no runtime or API behavior changes, and publish-time version resolution is unchanged.
> 
> **Overview**
> Aligns `@cypress-design/react-statusicon` with the rest of the monorepo by changing its `@cypress-design/react-icon` dependency from a pinned **`^3.0.0`** range to workspace **`*`**.
> 
> The lockfile is updated so install resolves `react-icon` via the local workspace alias only, which fixes **`yarn install --immutable`** failures on release PRs caused by changesets rewriting internal semver ranges without regenerating the lockfile. Published artifacts are unchanged because **`scripts/set-version.mjs`** still expands `*` to the correct `^version` at publish time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68fd7db6910d9acda4c44ec7ab42ea7634ade319. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->